### PR TITLE
feat: 用語検索の related_terms 対応（タスク 2.3）

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -294,7 +294,7 @@ JupyterLabのフロントエンド拡張。AIの操作をノートブック上�
 1. AI → document-mcp: get_term_index(query="略称") で検索（略称・不明用語がある場合）
    または get_term_index() で全件取得（全体像把握）
 2. document-mcp → document-server: GET /glossary/index?query=略称
-3. document-server: name + aliases（第2層で管理）を部分一致検索
+3. document-server: name + aliases + related_terms（第2層で管理）を部分一致検索
 4. document-mcp → AI: ヒットした用語インデックス
 
 5. AI → document-mcp: get_term_detail(["ロイヤルティランク", "統合会員ID"])

--- a/docs/plan/02-document.md
+++ b/docs/plan/02-document.md
@@ -29,7 +29,7 @@ PostgreSQLにCSVデータを初期ロードし、データカタログ（テー�
 |---|--------|-----------|-----------|------|
 | 2.1 | 用語集検索機能（サーバー＋MCP） | [x] | get_term_index(query="PC") で aliases に "PC" を含む用語がヒットし、get_term_detail で詳細取得できる | document-server: GET /glossary/index に query パラメータ追加・検索インデックス構築、document-mcp: get_term_index に query パラメータ追加。document-server 89テスト、document-mcp 54テスト全パス |
 | 2.2 | 用語の書き方ガイド作成 | [x] | - | docs/guides/add-term.md：aliases の書き方、各フィールドの説明 |
-| 2.3 | 用語検索の related_terms 対応 | [ ] | get_term_index(query="ヒルズID") で related_terms に「ヒルズID」を含む用語（例: 3Key認証）がヒットする | document-server: 検索インデックスに related_terms を追加。API レスポンス形式の変更なし |
+| 2.3 | 用語検索の related_terms 対応 | [x] | get_term_index(query="ヒルズID") で related_terms に「ヒルズID」を含む用語（例: 3Key認証）がヒットする | document-server: 検索インデックスに related_terms を追加。API レスポンス形式の変更なし |
 
 ---
 

--- a/docs/tasks/document/2.3-term-search-related-terms.md
+++ b/docs/tasks/document/2.3-term-search-related-terms.md
@@ -1,0 +1,61 @@
+# タスク詳細: 2.3 用語検索の related_terms 対応
+
+## 概要
+
+用語検索（`GET /glossary/index?query=...`）の検索インデックスに `related_terms` を追加する。これにより、関連用語名で検索しても該当する用語がヒットするようになる。
+
+例: `get_term_index(query="ヒルズID")` で `related_terms` に「ヒルズID」を含む用語（例: 3Key認証）がヒットする。
+
+API レスポンス形式の変更なし。
+
+## 関連ドキュメント
+
+- 要件定義: `docs/requirements/document-server.md` の「F3.1: 用語インデックス」セクション
+- API仕様: `docs/design/api-contracts.md` の「GET /glossary/index」セクション
+- 類似タスク: `docs/tasks/document/2.1-glossary-search.md`
+
+## 実装計画
+
+### 変更するファイル
+
+| ファイル | 内容 |
+|----------|------|
+| `document-server/src/catalog_loader.py` | `_build_term_search_index` に `related_terms` のキーワード追加 |
+| `document-server/tests/test_terms_api.py` | `related_terms` 経由の検索テスト追加 |
+
+### 実装手順
+
+1. **Red フェーズ**: `test_terms_api.py` に related_terms 部分一致検索のテストを追加
+   - `test_get_term_index_with_query_related_term_match`: related_terms に含まれるキーワードで検索→該当用語がヒット
+   - 既存の conftest.py フィクスチャ（`SAMPLE_TERM_STAR_RANK_YAML` に `related_terms: ["統合会員ID"]` が存在）を活用
+   - テスト実行して失敗を確認
+2. **Green フェーズ**: `catalog_loader.py` の `_build_term_search_index` を修正
+   - `detail.related_terms` が存在する場合、各関連用語名を小文字化して `keywords` リストに追加（aliases と同じパターン）
+3. **Refactor フェーズ**: テスト通過を確認し、コードを整理
+
+### 技術的な考慮事項
+
+- `related_terms` は `list[str] | None` 型のため、`None` チェックが必要
+- aliases と同じく小文字化して部分一致検索に対応
+- 用語数が限定的（数十〜数百）のため、related_terms 追加によるパフォーマンス影響は無視できる
+
+## 完了条件
+
+- [ ] `related_terms` に含まれるキーワードで検索した場合に該当用語がヒットする
+- [ ] 大文字小文字を区別しない検索が動作する
+- [ ] `related_terms` が `None` の用語でエラーが発生しない
+- [ ] 既存テスト（name, aliases 検索）が引き続きパスする
+- [ ] `scripts/test.sh --rebuild document-server` が全テストパス
+
+## テスト計画
+
+- `test_get_term_index_with_query_related_term_match`: related_terms の値で検索→ヒット
+- 既存テスト（name/aliases 部分一致、大小文字無視、ヒットなし、全件返却）が引き続きパス
+
+---
+
+## レビューステータス
+
+- [x] 計画レビュー完了
+- [ ] 実装完了
+- [ ] テスト完了

--- a/document-server/src/catalog_loader.py
+++ b/document-server/src/catalog_loader.py
@@ -422,15 +422,13 @@ class CatalogStore:
         return len(indexes)
 
     def _build_term_search_index(self) -> None:
-        """全用語詳細から aliases を読み込み、検索インデックスを構築する。"""
+        """全用語詳細から aliases と related_terms を読み込み、検索インデックスを構築する。"""
         index: dict[str, list[str]] = {}
         for name, detail in self._term_details.items():
-            keywords = [name.lower()]
-            for alias in detail.aliases:
-                lowered = alias.lower()
-                if lowered not in keywords:
-                    keywords.append(lowered)
-            index[name] = keywords
+            keywords: set[str] = {name.lower()}
+            for term in detail.aliases + (detail.related_terms or []):
+                keywords.add(term.lower())
+            index[name] = list(keywords)
         self._term_search_index = index
         logger.info("Term search index built: %d entries", len(index))
 

--- a/document-server/src/routers/terms.py
+++ b/document-server/src/routers/terms.py
@@ -13,7 +13,9 @@ router = APIRouter(prefix="/glossary", tags=["glossary"])
 @router.get("/index")
 def get_term_index(
     store: CatalogStore = Depends(get_catalog_store),
-    query: str | None = Query(default=None, max_length=200, description="検索キーワード（name + aliases 部分一致）"),
+    query: str | None = Query(
+        default=None, max_length=200, description="検索キーワード（name、aliases、related_terms 部分一致）"
+    ),
 ) -> dict:
     if query:
         terms = [t.model_dump() for t in store.search_term_indexes(query)]

--- a/document-server/tests/test_terms_api.py
+++ b/document-server/tests/test_terms_api.py
@@ -102,6 +102,16 @@ def test_get_term_index_with_query_no_match(client: TestClient) -> None:
     assert data["terms"] == []
 
 
+def test_get_term_index_with_query_related_term_match(client: TestClient) -> None:
+    """query で related_terms に部分一致する用語が返る。"""
+    resp = client.get("/glossary/index", params={"query": "統合会員ID"})
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    names = {t["name"] for t in data["terms"]}
+    # 「ロイヤルティランク」は related_terms に「統合会員ID」を含むのでヒットする
+    assert "ロイヤルティランク" in names
+
+
 def test_get_term_index_with_query_case_insensitive(client: TestClient) -> None:
     """query は大文字小文字を区別しない。"""
     resp_lower = client.get("/glossary/index", params={"query": "loyalty rank"})


### PR DESCRIPTION
## Summary
- 用語検索インデックスに `related_terms` を追加し、関連用語名での部分一致検索を可能にした
- `_build_term_search_index` で `aliases` と `related_terms` を統合してキーワードセットを構築
- テスト追加（`test_get_term_index_with_query_related_term_match`）、全113テストパス

## Test plan
- [x] `scripts/test.sh --rebuild document-server` 全113テストパス
- [x] related_terms での検索ヒット確認
- [x] related_terms が None の用語でエラーなし
- [x] 既存テスト（name, aliases 検索）が引き続きパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)