### PR TITLE
docs: PR のマージ判断をユーザーに委ねるワークフローに変更

### DIFF
--- a/.claude/commands/custom-auto-dev.md
+++ b/.claude/commands/custom-auto-dev.md
@@ -366,14 +366,12 @@ Agent ツールでサブエージェントを起動してください。
 
 ---
 
-## 3. PR 作成 + CI 待機 + ブランチクリーンアップ
+## 3. PR 作成
 
 すべてのタスクが完了したら：
 
 1. `.claude/rules/branch-workflow.md` の「PR 作成」に従い、feature → dev の PR を作成する
-2. `.claude/rules/branch-workflow.md` の「CI 待機 + dev 切り替え + ブランチ削除」に従い、CI パスを待ってから dev に切り替え、ローカルブランチを削除する
-
-CI が失敗した場合はブランチを削除せず、修正を案内して停止してください。
+2. PR URL を報告して停止する。CI 待機・マージ・ブランチ削除は**ユーザーの判断に委ねる**（`.claude/rules/branch-workflow.md` の「PR のマージ判断はユーザーが行う」を参照）
 
 ## 4. 全タスク完了報告
 

--- a/.claude/commands/custom-complete-task.md
+++ b/.claude/commands/custom-complete-task.md
@@ -143,11 +143,7 @@ dev ブランチ上にいる場合は、対象タスクの feature ブランチ�
 
 `.claude/rules/branch-workflow.md` の「PR 作成」に従い、feature → dev の PR を作成してください。
 
-### 6c. CI 待機 + ブランチクリーンアップ
-
-`.claude/rules/branch-workflow.md` の「CI 待機 + dev 切り替え + ブランチ削除」に従い、CI パスを待ってから dev に切り替え、ローカルブランチを削除してください。
-
-CI が失敗した場合はブランチを削除せず、修正を案内して停止してください。
+PR 作成後は PR URL を報告して停止します。CI 待機・マージ・ブランチ削除は**ユーザーの判断に委ねる**（`.claude/rules/branch-workflow.md` の「PR のマージ判断はユーザーが行う」を参照）。
 
 ## 7. 次のタスクの提案
 

--- a/.claude/commands/custom-start-fix.md
+++ b/.claude/commands/custom-start-fix.md
@@ -94,7 +94,7 @@ git status
 
 4. `.claude/rules/branch-workflow.md` の「PR 作成」に従い、fix → dev の PR を作成する
 
-5. `.claude/rules/branch-workflow.md` の「CI 待機 + dev 切り替え + ブランチ削除」に従い、CI パス後に Issue をクローズし、dev に切り替えてローカルブランチを削除する。CI が失敗した場合は Issue をクローズせず、ブランチも削除せず、修正を案内して停止する
+5. PR URL を報告して停止する。CI 待機・マージ・Issue クローズ・ブランチ削除は**ユーザーの判断に委ねる**（`.claude/rules/branch-workflow.md` の「PR のマージ判断はユーザーが行う」を参照）
 
 6. 以下の形式で報告する：
    ```

--- a/.claude/rules/branch-workflow.md
+++ b/.claude/rules/branch-workflow.md
@@ -15,7 +15,18 @@ main (公開・リリース済み、直接 push 禁止)
 - **すべての変更は `feature/*` または `fix/*` ブランチで行い、PR 経由で `dev` にマージする**（ドキュメントのみの変更も含む）
 - `dev` / `main` への直接 push は GitHub ブランチ保護で拒否される
 - PR マージには CI（4 ジョブ）のパスが必須
+- **PR のマージ判断はユーザーが行う**（Claude は PR 作成までで停止する）
 - `main` への反映は `scripts/promote-to-main.sh` 経由で PR を作成する
+
+### PR のマージ判断はユーザーが行う
+
+Claude は feature/fix → dev の PR を**作成するまで**を担当し、マージは実行しない。
+
+- CI 待機・`gh pr merge`・dev 切り替え・ローカルブランチ削除・Issue クローズは、**ユーザーが実施する**か、**ユーザーから明示的に依頼を受けた時のみ** Claude が実行する
+- Claude は `gh pr checks --watch` 等でバックグラウンド CI 監視を起動しない
+- PR 作成後は PR URL を報告してコマンドを終了する
+
+理由: dev に何を入れるかはユーザーが判断する。複数の open PR から採用するものを選ぶ運用のため、自動マージしない。
 
 ### ドキュメントのみの変更
 
@@ -75,19 +86,18 @@ EOF
 
 PR タイトルは短く（70文字以内）。詳細は body に記述する。
 
-### CI 待機 + dev 切り替え + ブランチ削除
+### マージ後のクリーンアップ（ユーザー依頼時のみ）
 
-PR 作成後、CI の完了を待ち、dev に切り替えてローカルブランチを削除する。
-リモートブランチは GitHub の「PR マージ時に自動削除」設定で削除される。
+ユーザーから明示的に依頼された場合のみ実行する。PR 作成直後に自動実行してはならない。
 
 ```bash
 # 現在のブランチ名を記録
 BRANCH=$(git branch --show-current)
 
-# CI 完了を待機
-gh pr checks {PR番号} --watch
+# PR をマージ（merge commit 方式 + リモートブランチ削除）
+gh pr merge {PR番号} --merge --delete-branch
 
-# CI パス → dev に切り替え
+# dev に切り替え
 git checkout dev
 git pull origin dev
 
@@ -95,9 +105,9 @@ git pull origin dev
 git branch -d "$BRANCH"
 ```
 
-CI が失敗した場合はブランチを削除せず、修正を案内する。
+リモートブランチは `--delete-branch` オプションで削除される。
 
-バグ修正 PR の場合は、dev 切り替え前に Issue もクローズする：
+バグ修正 PR の場合は、マージ前に Issue もクローズする：
 
 ```bash
 gh issue close {Issue番号}
@@ -116,3 +126,5 @@ PR 経由で `feature/*` または `fix/*` → `dev` にマージ。
 - `main` ブランチで `git commit` を実行すること（フックでブロックされる）
 - `main` / `dev` ブランチに直接 `git push` すること（GitHub ブランチ保護で拒否される）
 - 変更を `dev` ブランチで直接行うこと（ドキュメント変更も含め feature/fix ブランチを使う）
+- Claude が PR を自動マージすること（ユーザーの明示的な依頼がない限り実行しない）
+- Claude が `gh pr checks --watch` 等でバックグラウンド CI 監視を起動すること


### PR DESCRIPTION
## Summary
- PR 作成後の CI 待機・マージ・ブランチ削除を Claude は自動実行しない運用に変更
- ユーザーが明示的に依頼した時のみ、マージ後のクリーンアップを Claude が実行
- dev にマージするかの判断をユーザーがコントロールできるようにする

## 変更内容
- `.claude/rules/branch-workflow.md`:
  - 「PR のマージ判断はユーザーが行う」セクションを追加
  - 「CI 待機 + dev 切り替え + ブランチ削除」を「マージ後のクリーンアップ（ユーザー依頼時のみ）」に改名
  - `gh pr merge --merge --delete-branch` の手順を明示化
  - 禁止事項に「Claude による自動マージ」「バックグラウンド CI 監視」を追加
- `.claude/commands/custom-complete-task.md`: 6c（CI 待機 + ブランチクリーンアップ）を削除
- `.claude/commands/custom-start-fix.md`: ステップ5（CI 待機 + Issue クローズ + ブランチ削除）を削除
- `.claude/commands/custom-auto-dev.md`: セクション3 から CI 待機・ブランチクリーンアップを削除

## Test plan
- ドキュメントのみの変更のため CI パスを確認
- マージ後、次回の custom-complete-task 等が PR 作成で停止することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)