### PR TITLE
feat: マージ済みローカルブランチの自動削除機能

### DIFF
--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -24,6 +24,7 @@
 | `scripts/convert-csv-to-parquet.py [ENV]` | CSV→Parquet変換（既存Parquetはスキップ、`--force`で再変換） | `scripts/convert-csv-to-parquet.py production` |
 | `scripts/clean-rebuild.sh` | 全削除→クリーンビルド→動作確認 | `scripts/clean-rebuild.sh --env sample -y` |
 | `scripts/promote-to-main.sh` | dev → main プロモーション PR 作成 | `scripts/promote-to-main.sh` |
+| `scripts/cleanup-merged-branches.sh` | dev にマージ済みのローカル feature/fix ブランチを削除 | `scripts/cleanup-merged-branches.sh` |
 
 ## よく使うパターン
 

--- a/.githooks/post-merge
+++ b/.githooks/post-merge
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# post-merge: dev で git pull / git merge 完了後、
+#             dev にマージ済みのローカル feature/fix ブランチを掃除する
+
+current_branch=$(git branch --show-current)
+if [[ "$current_branch" != "dev" ]]; then
+  exit 0
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+CLEANUP="$REPO_ROOT/scripts/cleanup-merged-branches.sh"
+
+if [[ -x "$CLEANUP" ]]; then
+  "$CLEANUP"
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,18 @@ npm run dev        # MCPサーバー
 jupyter lab        # jupyter-server
 ```
 
+## 初回セットアップ
+
+clone 後に 1 度だけ実行する：
+
+```bash
+# git hooks を有効化（dev pull 時にマージ済みローカルブランチを自動削除）
+git config core.hooksPath .githooks
+
+# fetch 時に削除済みリモートブランチの追跡参照を自動削除
+git config fetch.prune true
+```
+
 ## ブランチ運用
 
 ```

--- a/scripts/cleanup-merged-branches.sh
+++ b/scripts/cleanup-merged-branches.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# cleanup-merged-branches.sh — dev にマージ済みのローカルブランチを削除する
+#
+# 削除対象の条件（すべて満たす場合のみ削除）:
+#   - ブランチ名が feature/* または fix/* にマッチ
+#   - dev にマージ済み（git branch --merged dev）
+#   - main / dev ではない
+#   - 現在チェックアウト中のブランチではない
+
+PROTECTED_PATTERN="^(main|dev)$"
+TARGET_PATTERN="^(feature|fix)/"
+
+current_branch=$(git branch --show-current)
+
+# dev にマージ済みのブランチを取得
+merged_branches=$(git branch --merged dev --format='%(refname:short)' | grep -E "$TARGET_PATTERN" || true)
+
+if [[ -z "$merged_branches" ]]; then
+  exit 0
+fi
+
+deleted=()
+while IFS= read -r branch; do
+  [[ -z "$branch" ]] && continue
+  if [[ "$branch" =~ $PROTECTED_PATTERN ]]; then
+    continue
+  fi
+  if [[ "$branch" == "$current_branch" ]]; then
+    continue
+  fi
+  if git branch -d "$branch" >/dev/null 2>&1; then
+    deleted+=("$branch")
+  fi
+done <<< "$merged_branches"
+
+if [[ ${#deleted[@]} -gt 0 ]]; then
+  echo "Cleaned up merged local branches:"
+  printf '  - %s\n' "${deleted[@]}"
+fi


### PR DESCRIPTION
## Summary
- dev で git pull した際に、dev にマージ済みのローカル feature/fix ブランチを自動削除する
- git post-merge フックで実現。初回セットアップで `core.hooksPath .githooks` を設定する

## 変更内容
- `scripts/cleanup-merged-branches.sh`: 削除対象を判定して実行
- `.githooks/post-merge`: dev pull 後にスクリプトを呼び出す
- `CLAUDE.md`: 初回セットアップ手順を追記
- `.claude/rules/scripts.md`: スクリプト一覧に追加

## 安全条件
- feature/* または fix/* のみ対象（main/dev は保護）
- dev にマージ済みのブランチのみ削除（未マージは `git branch --merged dev` に出ないため削除されない）
- 現在チェックアウト中のブランチは削除されない

## Test plan
- PR マージ後、`git config core.hooksPath .githooks` を設定（本 PR のマージ時点で Claude ローカル環境では設定済み）
- `git checkout dev && git pull origin dev` を実行
- ローカルにマージ済み feature ブランチがあれば削除されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)