### PR TITLE
docs: gh コマンドの heredoc 例外を撤廃し tmp/ ファイル経由に統一

### DIFF
--- a/.claude/commands/custom-report-bug.md
+++ b/.claude/commands/custom-report-bug.md
@@ -100,8 +100,11 @@ scripts/create-test-issue.sh \
 
 以下のコマンドで Issue を起票してください：
 
-```bash
-gh issue create --title "bug: {バグの概要}" --body "$(cat <<'EOF'
+Issue 本文は `tmp/issue-body.md` に書き出してから `gh issue create` に渡す（heredoc 禁止）。
+
+1. Write ツールで `tmp/issue-body.md` を作成:
+
+```markdown
 ## 症状
 
 {バグの症状を記述}
@@ -123,9 +126,15 @@ gh issue create --title "bug: {バグの概要}" --body "$(cat <<'EOF'
 ## 関連タスク
 
 - {PLAN.md のタスク番号。不明な場合は「不明」}
-EOF
-)"
 ```
+
+2. Issue を起票:
+
+```bash
+gh issue create --title "bug: {バグの概要}" --body "$(cat tmp/issue-body.md)"
+```
+
+`tmp/issue-body.md` は起票後に削除する。
 
 起票された Issue 番号を控えてください。
 

--- a/.claude/commands/custom-report-bug.md
+++ b/.claude/commands/custom-report-bug.md
@@ -131,7 +131,7 @@ Issue 本文は `tmp/issue-body.md` に書き出してから `gh issue create` �
 2. Issue を起票:
 
 ```bash
-gh issue create --title "bug: {バグの概要}" --body "$(cat tmp/issue-body.md)"
+gh issue create --title "bug: {バグの概要}" --body-file tmp/issue-body.md
 ```
 
 `tmp/issue-body.md` は起票後に削除する。

--- a/.claude/hooks/block-heredoc-adhoc.sh
+++ b/.claude/hooks/block-heredoc-adhoc.sh
@@ -47,7 +47,7 @@ tmp/ は .gitignore 済みなのでコミットされません。
 
 例外: git commit のヒアドキュメントのみ許可されています。
 gh pr create / gh issue create の本文は tmp/ ファイルに書き出し、
-$(cat tmp/pr-body.md) で渡してください。
+--body-file tmp/pr-body.md で渡してください。
 
 詳細: .claude/rules/adhoc-script-execution.md
 ========================================

--- a/.claude/hooks/block-heredoc-adhoc.sh
+++ b/.claude/hooks/block-heredoc-adhoc.sh
@@ -27,11 +27,6 @@ if echo "$COMMAND" | grep -qE '^[[:space:]]*git[[:space:]]+commit'; then
   exit 0
 fi
 
-# gh pr create / gh issue create のヒアドキュメントも例外
-if echo "$COMMAND" | grep -qE '^[[:space:]]*gh[[:space:]]+(pr|issue)[[:space:]]+(create|comment|edit)'; then
-  exit 0
-fi
-
 # それ以外の heredoc はブロックし、修正手順を Claude に返す
 cat >&2 <<'EOF'
 ========================================
@@ -50,7 +45,9 @@ cat >&2 <<'EOF'
 使い終わった tmp/ スクリプトは削除してください。
 tmp/ は .gitignore 済みなのでコミットされません。
 
-例外: git commit / gh pr create のヒアドキュメントは許可されています。
+例外: git commit のヒアドキュメントのみ許可されています。
+gh pr create / gh issue create の本文は tmp/ ファイルに書き出し、
+$(cat tmp/pr-body.md) で渡してください。
 
 詳細: .claude/rules/adhoc-script-execution.md
 ========================================

--- a/.claude/rules/branch-workflow.md
+++ b/.claude/rules/branch-workflow.md
@@ -123,7 +123,7 @@ git push -u origin {ブランチ名}
 2. PR を作成:
 
 ```bash
-gh pr create --base dev --title "{タイトル}" --body "$(cat tmp/pr-body.md)"
+gh pr create --base dev --title "{タイトル}" --body-file tmp/pr-body.md
 ```
 
 PR タイトルは短く（70文字以内）。詳細は body に記述する。

--- a/.claude/rules/branch-workflow.md
+++ b/.claude/rules/branch-workflow.md
@@ -102,9 +102,15 @@ git checkout {ブランチ名}
 
 ### PR 作成（feature/fix → dev）
 
+PR 本文は `tmp/pr-body.md` に書き出してから `gh pr create` に渡す（heredoc 禁止）。
+
 ```bash
 git push -u origin {ブランチ名}
-gh pr create --base dev --title "{タイトル}" --body "$(cat <<'EOF'
+```
+
+1. Write ツールで `tmp/pr-body.md` を作成:
+
+```markdown
 ## Summary
 {箇条書きで変更内容}
 
@@ -112,11 +118,16 @@ gh pr create --base dev --title "{タイトル}" --body "$(cat <<'EOF'
 {テスト計画}
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)"
+```
+
+2. PR を作成:
+
+```bash
+gh pr create --base dev --title "{タイトル}" --body "$(cat tmp/pr-body.md)"
 ```
 
 PR タイトルは短く（70文字以内）。詳細は body に記述する。
+`tmp/pr-body.md` は PR 作成後に削除する。
 
 ### マージ後のクリーンアップ（ユーザー依頼時のみ）
 


### PR DESCRIPTION
## Summary
- `block-heredoc-adhoc.sh` フックから `gh pr/issue create` の heredoc 例外を削除
- `branch-workflow.md` の PR 作成手順を `tmp/pr-body.md` 経由に変更
- `custom-report-bug.md` の Issue 起票手順を `tmp/issue-body.md` 経由に変更
- heredoc 禁止ルールを gh コマンドにも一律適用し、tmp/ ファイル経由に統一

## Test plan
- [ ] `gh pr create` に heredoc を使った場合にフックがブロックすることを確認
- [ ] `git commit` の heredoc は引き続き許可されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
