### PR TITLE
feat: ブランチ一括掃除スクリプト拡張とカスタムコマンド追加

### DIFF
--- a/.claude/commands/custom-cleanup-branches.md
+++ b/.claude/commands/custom-cleanup-branches.md
@@ -1,0 +1,19 @@
+不要なブランチを掃除します。
+
+## 手順
+
+1. まず `--dry-run` で削除対象を確認する：
+
+```bash
+scripts/cleanup-merged-branches.sh --all --dry-run
+```
+
+2. 結果をユーザーに提示し、削除してよいか確認する
+
+3. 承認されたら実行する：
+
+```bash
+scripts/cleanup-merged-branches.sh --all
+```
+
+4. 最終的なブランチ一覧（`git branch -a`）を表示して完了を報告する

--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -24,7 +24,7 @@
 | `scripts/convert-csv-to-parquet.py [ENV]` | CSV→Parquet変換（既存Parquetはスキップ、`--force`で再変換） | `scripts/convert-csv-to-parquet.py production` |
 | `scripts/clean-rebuild.sh` | 全削除→クリーンビルド→動作確認 | `scripts/clean-rebuild.sh --env sample -y` |
 | `scripts/promote-to-main.sh` | dev → main プロモーション PR 作成 | `scripts/promote-to-main.sh` |
-| `scripts/cleanup-merged-branches.sh` | dev にマージ済みのローカル feature/fix ブランチを削除 | `scripts/cleanup-merged-branches.sh` |
+| `scripts/cleanup-merged-branches.sh` | 不要ブランチの一括掃除（prune + ローカル + promote） | `scripts/cleanup-merged-branches.sh --all` |
 
 ## よく使うパターン
 
@@ -109,6 +109,11 @@ scripts/clean-rebuild.sh --env production   # production 環境で実行
 scripts/clean-rebuild.sh --keep-volumes     # DB データを保持してリビルド
 scripts/clean-rebuild.sh --skip-smoke       # スモークテストなし
 scripts/clean-rebuild.sh --skip-mcp        # MCP ビルドをスキップ（Docker のみ再構築）
+
+# 不要ブランチの掃除（prune + ローカル + promote + リモート）
+scripts/cleanup-merged-branches.sh --all --dry-run  # 削除対象の確認のみ
+scripts/cleanup-merged-branches.sh --all             # 全掃除（リモート含む）
+scripts/cleanup-merged-branches.sh                   # ローカルのみ（リモートは除外）
 ```
 
 ## Docker ゴミ溜まり対策

--- a/scripts/cleanup-merged-branches.sh
+++ b/scripts/cleanup-merged-branches.sh
@@ -1,41 +1,126 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# cleanup-merged-branches.sh — dev にマージ済みのローカルブランチを削除する
+# cleanup-merged-branches.sh — 不要ブランチを一括掃除する
 #
-# 削除対象の条件（すべて満たす場合のみ削除）:
-#   - ブランチ名が feature/* または fix/* にマッチ
-#   - dev にマージ済み（git branch --merged dev）
-#   - main / dev ではない
-#   - 現在チェックアウト中のブランチではない
+# Usage:
+#   scripts/cleanup-merged-branches.sh [OPTIONS]
+#
+# Options:
+#   --dry-run    削除せず、対象を一覧表示のみ
+#   --remote     リモートのマージ済み feature/fix ブランチも削除
+#   --all        --remote と同等（ローカル + リモート全掃除）
+#
+# 常に実行される処理:
+#   1. git remote prune origin（リモートで削除済みの追跡参照を削除）
+#   2. dev にマージ済みのローカル feature/fix ブランチを削除
+#   3. 不要な promote/* ローカルブランチを削除
+#
+# --remote / --all 指定時に追加される処理:
+#   4. dev にマージ済みのリモート feature/fix ブランチを削除
+
+DRY_RUN=false
+INCLUDE_REMOTE=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=true ;;
+    --remote|--all) INCLUDE_REMOTE=true ;;
+    *) echo "Unknown option: $arg" >&2; exit 1 ;;
+  esac
+done
 
 PROTECTED_PATTERN="^(main|dev)$"
 TARGET_PATTERN="^(feature|fix)/"
+PROMOTE_PATTERN="^promote/"
 
 current_branch=$(git branch --show-current)
 
-# dev にマージ済みのブランチを取得
-merged_branches=$(git branch --merged dev --format='%(refname:short)' | grep -E "$TARGET_PATTERN" || true)
+total_deleted=0
 
-if [[ -z "$merged_branches" ]]; then
-  exit 0
+# --- Step 1: Prune stale remote tracking references ---
+echo "=== Pruning stale remote tracking references ==="
+prune_output=$(git remote prune origin 2>&1)
+if [[ -n "$prune_output" ]]; then
+  echo "$prune_output"
+else
+  echo "  (nothing to prune)"
 fi
 
-deleted=()
-while IFS= read -r branch; do
-  [[ -z "$branch" ]] && continue
-  if [[ "$branch" =~ $PROTECTED_PATTERN ]]; then
-    continue
-  fi
-  if [[ "$branch" == "$current_branch" ]]; then
-    continue
-  fi
-  if git branch -d "$branch" >/dev/null 2>&1; then
-    deleted+=("$branch")
-  fi
-done <<< "$merged_branches"
+# --- Step 2: Delete merged local feature/fix branches ---
+echo ""
+echo "=== Merged local feature/fix branches ==="
+merged_local=$(git branch --merged dev --format='%(refname:short)' | grep -E "$TARGET_PATTERN" || true)
 
-if [[ ${#deleted[@]} -gt 0 ]]; then
-  echo "Cleaned up merged local branches:"
-  printf '  - %s\n' "${deleted[@]}"
+if [[ -n "$merged_local" ]]; then
+  while IFS= read -r branch; do
+    [[ -z "$branch" ]] && continue
+    [[ "$branch" =~ $PROTECTED_PATTERN ]] && continue
+    [[ "$branch" == "$current_branch" ]] && continue
+    if $DRY_RUN; then
+      echo "  (dry-run) would delete: $branch"
+    else
+      if git branch -d "$branch" >/dev/null 2>&1; then
+        echo "  deleted: $branch"
+        ((total_deleted++))
+      fi
+    fi
+  done <<< "$merged_local"
+else
+  echo "  (none)"
+fi
+
+# --- Step 3: Delete local promote/* branches ---
+echo ""
+echo "=== Local promote/* branches ==="
+promote_local=$(git branch --format='%(refname:short)' | grep -E "$PROMOTE_PATTERN" || true)
+
+if [[ -n "$promote_local" ]]; then
+  while IFS= read -r branch; do
+    [[ -z "$branch" ]] && continue
+    [[ "$branch" == "$current_branch" ]] && continue
+    if $DRY_RUN; then
+      echo "  (dry-run) would delete: $branch"
+    else
+      if git branch -D "$branch" >/dev/null 2>&1; then
+        echo "  deleted: $branch"
+        ((total_deleted++))
+      fi
+    fi
+  done <<< "$promote_local"
+else
+  echo "  (none)"
+fi
+
+# --- Step 4: Delete merged remote feature/fix branches (opt-in) ---
+if $INCLUDE_REMOTE; then
+  echo ""
+  echo "=== Merged remote feature/fix branches ==="
+  merged_remote=$(git branch -r --merged dev | grep -E 'origin/(feature|fix)/' | sed 's|^ *origin/||' || true)
+
+  if [[ -n "$merged_remote" ]]; then
+    while IFS= read -r branch; do
+      [[ -z "$branch" ]] && continue
+      if $DRY_RUN; then
+        echo "  (dry-run) would delete remote: $branch"
+      else
+        if git push origin --delete "$branch" >/dev/null 2>&1; then
+          echo "  deleted remote: $branch"
+          ((total_deleted++))
+        else
+          echo "  skipped (already deleted?): $branch"
+        fi
+      fi
+    done <<< "$merged_remote"
+  else
+    echo "  (none)"
+  fi
+fi
+
+# --- Summary ---
+echo ""
+if $DRY_RUN; then
+  echo "Dry run complete. No branches were deleted."
+else
+  echo "Done. Deleted $total_deleted branch(es)."
 fi


### PR DESCRIPTION
## Summary
- `scripts/cleanup-merged-branches.sh` を拡張: `--remote`/`--all`/`--dry-run` オプション追加
  - prune（リモート削除済み追跡参照の掃除）
  - promote/* ローカルブランチの削除
  - リモートのマージ済み feature/fix ブランチ削除（`--remote`/`--all` 指定時）
- `/custom-cleanup-branches` カスタムコマンドを新規追加（DRY 原則に従いスクリプトを呼ぶだけ）
- `.claude/rules/scripts.md` のスクリプト一覧・よく使うパターンを更新

## Test plan
- [ ] `scripts/cleanup-merged-branches.sh --dry-run` で削除対象が正しく表示される
- [ ] `scripts/cleanup-merged-branches.sh --all --dry-run` でリモートブランチも対象に含まれる
- [ ] `scripts/cleanup-merged-branches.sh` でローカルブランチが削除される

🤖 Generated with [Claude Code](https://claude.com/claude-code)
