### PR TITLE
feat: セル結合・分割ツールを実装 (タスク19.2)

### DIFF
--- a/docs/plan/01-jupyter.md
+++ b/docs/plan/01-jupyter.md
@@ -226,7 +226,7 @@ SQLクエリ結果を大量行対応でワークスペースにファイル保�
 | # | タスク | ステータス | E2Eテスト | 備考 |
 |---|--------|-----------|-----------|------|
 | 19.1 | セル一括実行 | [x] | notebook_execute_batch で全セル/ここまで/これ以降の一括実行ができる | jupyter-server: POST /cells/execute-batch、jupyter-mcp: notebook_execute_batch |
-| 19.2 | セル結合・分割 | [→] | notebook_merge_cells で隣接セルが結合され、notebook_split_cell でセルが分割される | jupyter-server: PATCH /cells (action: merge/split)、jupyter-mcp: 2ツール |
+| 19.2 | セル結合・分割 | [x] | notebook_merge_cells で隣接セルが結合され、notebook_split_cell でセルが分割される | jupyter-server: PATCH /cells (action: merge/split)、jupyter-mcp: 2ツール |
 | 19.3 | セルタイプ変更・コピー | [ ] | notebook_change_cell_type でセルタイプが変更され、notebook_copy_cell でセルが複製される | jupyter-server: PATCH /cells (action: change_type/copy)、jupyter-mcp: 2ツール |
 | 19.4 | 出力クリア | [ ] | notebook_clear_outputs で単一セル/全セルの出力がクリアされる | jupyter-server: PATCH /cells (action: clear_output) + POST /cells/clear-all-outputs、jupyter-mcp: 1ツール |
 | 19.5 | カーネル再起動・再起動+全セル実行 | [ ] | kernel_restart でカーネルが再起動され、kernel_restart_and_run_all で再起動後に全セルが実行される | jupyter-server: POST /restart-and-run-all、jupyter-mcp: 2ツール |

--- a/docs/plan/01-jupyter.md
+++ b/docs/plan/01-jupyter.md
@@ -226,7 +226,7 @@ SQLクエリ結果を大量行対応でワークスペースにファイル保�
 | # | タスク | ステータス | E2Eテスト | 備考 |
 |---|--------|-----------|-----------|------|
 | 19.1 | セル一括実行 | [x] | notebook_execute_batch で全セル/ここまで/これ以降の一括実行ができる | jupyter-server: POST /cells/execute-batch、jupyter-mcp: notebook_execute_batch |
-| 19.2 | セル結合・分割 | [ ] | notebook_merge_cells で隣接セルが結合され、notebook_split_cell でセルが分割される | jupyter-server: PATCH /cells (action: merge/split)、jupyter-mcp: 2ツール |
+| 19.2 | セル結合・分割 | [→] | notebook_merge_cells で隣接セルが結合され、notebook_split_cell でセルが分割される | jupyter-server: PATCH /cells (action: merge/split)、jupyter-mcp: 2ツール |
 | 19.3 | セルタイプ変更・コピー | [ ] | notebook_change_cell_type でセルタイプが変更され、notebook_copy_cell でセルが複製される | jupyter-server: PATCH /cells (action: change_type/copy)、jupyter-mcp: 2ツール |
 | 19.4 | 出力クリア | [ ] | notebook_clear_outputs で単一セル/全セルの出力がクリアされる | jupyter-server: PATCH /cells (action: clear_output) + POST /cells/clear-all-outputs、jupyter-mcp: 1ツール |
 | 19.5 | カーネル再起動・再起動+全セル実行 | [ ] | kernel_restart でカーネルが再起動され、kernel_restart_and_run_all で再起動後に全セルが実行される | jupyter-server: POST /restart-and-run-all、jupyter-mcp: 2ツール |

--- a/docs/requirements/jupyter-mcp.md
+++ b/docs/requirements/jupyter-mcp.md
@@ -902,7 +902,7 @@ SQLクエリの結果をデータセットとしてワークスペースにフ�
       },
       split_line: {
         type: "number",
-        description: "分割行番号（0-indexed、この行から下が新しいセルになる）"
+        description: "分割行番号（1-indexed、この行から下が新しいセルになる）"
       }
     },
     required: ["notebook_path", "cell_index", "split_line"]

--- a/docs/tasks/jupyter/19.2-cell-merge-split.md
+++ b/docs/tasks/jupyter/19.2-cell-merge-split.md
@@ -1,0 +1,149 @@
+# タスク詳細: 19.2 セル結合・分割
+
+## 概要
+
+隣接する複数セルを1つに結合する `notebook_merge_cells` と、1つのセルを指定行で2つに分割する `notebook_split_cell` を実装する。jupyter-server の `PATCH /cells` に `merge`/`split` アクションを追加し、jupyter-mcp に2つのMCPツールを新規作成する。
+
+## 関連ドキュメント
+
+- 要件定義: `docs/requirements/jupyter-server.md` の「F3.3: セル操作」セクション
+- 要件定義: `docs/requirements/jupyter-mcp.md` の「F3.2: セル操作」セクション、「notebook_merge_cells」「notebook_split_cell」ツール定義
+- API仕様: `docs/design/api-contracts.md` の「PATCH /api/custom/contents/{path}/cells (action: merge/split)」セクション
+- 受け入れ条件: `docs/requirements/jupyter-mcp.md` の「AC13: セル一括操作」
+
+## 実装計画
+
+### 作成するファイル
+
+| ファイル | 内容 |
+|----------|------|
+| `jupyter-server/tests/test_cell_merge_split.py` | jupyter-server ユニットテスト（TDD: Red フェーズで先に作成） |
+| `jupyter-mcp/tests/unit/tools/notebook-merge-cells.test.ts` | notebook_merge_cells ユニットテスト |
+| `jupyter-mcp/tests/unit/tools/notebook-split-cell.test.ts` | notebook_split_cell ユニットテスト |
+| `jupyter-mcp/src/tools/notebook-merge-cells.ts` | notebook_merge_cells ツール実装 |
+| `jupyter-mcp/src/tools/notebook-split-cell.ts` | notebook_split_cell ツール実装 |
+
+### 修正するファイル
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `jupyter-server/extensions/custom_api/handlers.py` | `ContentsCellsHandler.patch()` に `merge`/`split` アクションを追加 |
+| `jupyter-mcp/src/jupyter-client/types.ts` | `CellAction` 型に `'merge' \| 'split'` を追加、`CellOperationRequest` にパラメータ追加 |
+| `jupyter-mcp/src/jupyter-client/client.ts` | 必要に応じて `operateCell()` の型を調整（既存メソッドで対応可能な見込み） |
+| `jupyter-mcp/src/tools/index.ts` | 2ツールを `toolRegistry` に登録、`NOTEBOOK_EDIT_TOOLS` に追加 |
+| `jupyter-mcp/tests/unit/tools/index.test.ts` | ツール登録数の更新 |
+
+### 実装手順
+
+#### 1. テスト作成（Red フェーズ）
+
+1-1. `jupyter-server/tests/test_cell_merge_split.py` を作成
+  - 既存パターン（`test_cell_execute_batch.py`）に倣い、モック登録 + `importlib` で `handlers.py` をロード
+  - merge 正常系: 2セル結合、3セル以上結合、ソースコードが `\n` 区切りで連結されること
+  - merge 異常系: `start_index` > `end_index`、範囲外インデックス、セル数1（結合不可）、セルタイプ混在
+  - split 正常系: セルを中間行で分割、先頭行で分割、最終行で分割
+  - split 異常系: 範囲外インデックス、範囲外 `split_line`、1行セルの `split_line=0`（前半が空）
+
+1-2. `jupyter-mcp/tests/unit/tools/notebook-merge-cells.test.ts` を作成
+  - 既存パターン（`notebook-delete-cell.test.ts`）に倣う
+  - 正常系: 基本的な結合呼び出し
+  - 異常系: `notebook_path` 未指定、`start_index` 未指定、`end_index` 未指定、パストラバーサル、APIエラー
+
+1-3. `jupyter-mcp/tests/unit/tools/notebook-split-cell.test.ts` を作成
+  - 正常系: 基本的な分割呼び出し
+  - 異常系: `notebook_path` 未指定、`cell_index` 未指定、`split_line` 未指定、パストラバーサル、APIエラー
+
+#### 2. jupyter-server 実装（Green フェーズ）
+
+2-1. `handlers.py` の `ContentsCellsHandler.patch()` に `merge` アクションを追加
+  - `start_index`, `end_index` をリクエストボディから取得
+  - バリデーション: 両方必須、`start_index` <= `end_index`、範囲内チェック、全セルが同一セルタイプであることを検証（混在時はバリデーションエラー）
+  - 処理: `cells[start_index]` から `cells[end_index]` までのソースを `\n` で連結し、先頭セルのソースを更新、残りのセルを削除
+  - 結合後のセルタイプは元のセルタイプを維持（全セル同一型のため）
+
+2-2. `handlers.py` に `split` アクションを追加
+  - `index`, `split_line` をリクエストボディから取得
+  - バリデーション: 両方必須、`index` が範囲内、`split_line` が 0 以上かつソース行数未満
+  - 処理: セルのソースを `split_line` で前半・後半に分割、後半を新しいセルとして `index + 1` に挿入
+  - 分割後のセルタイプは元のセルタイプを維持、出力と `execution_count` はクリア
+
+#### 3. jupyter-mcp 型定義・クライアント
+
+3-1. `types.ts` の `CellAction` に `'merge' | 'split'` を追加
+3-2. `CellOperationRequest` に `start_index`, `end_index`, `split_line` を optional で追加
+3-3. `client.ts` の `operateCell()` は既存のまま利用可能（PATCH /cells に action を送るだけ）
+
+#### 4. jupyter-mcp ツール実装
+
+4-1. `notebook-merge-cells.ts` を作成（`notebook-delete-cell.ts` をテンプレートに）
+  - `validateAndNormalizeNotebookPath` でパス検証
+  - `start_index`, `end_index` の必須チェック・数値チェック
+  - `jupyterClient.operateCell()` で `{ action: 'merge', start_index, end_index }` を送信
+  - `jupyterClient.postAiEvent()` でリアルタイム同期イベント配信
+
+4-2. `notebook-split-cell.ts` を作成
+  - `validateAndNormalizeNotebookPath` でパス検証
+  - `cell_index`, `split_line` の必須チェック・数値チェック
+  - `jupyterClient.operateCell()` で `{ action: 'split', index: cell_index, split_line }` を送信
+  - `jupyterClient.postAiEvent()` でリアルタイム同期イベント配信
+
+#### 5. ツール登録
+
+5-1. `index.ts` の `toolRegistry` に2ツールのエントリを追加
+5-2. `NOTEBOOK_EDIT_TOOLS` Set に `'notebook_merge_cells'`, `'notebook_split_cell'` を追加
+5-3. `index.test.ts` のツール登録数を更新（+2）
+
+### 技術的な考慮事項
+
+- **merge のソース連結区切り**: `\n` で連結する。各セルのソースが末尾改行を含むかは実行時に確認し、二重改行を避ける
+- **merge のセルタイプ混在禁止**: code + markdown の混在結合はバリデーションエラーとする。結合対象の全セルが同一セルタイプ（code のみ、または markdown のみ）であることを検証する
+- **split 後のメタデータ**: 分割後の両セルとも `outputs` は空配列、`execution_count` は `null` にリセットする（コードの意味が変わるため）
+- **AI 編集ロック**: `NOTEBOOK_EDIT_TOOLS` に追加することで `handleToolCall` ミドルウェアが自動的にロック/アンロックを制御する
+- **リアルタイム同期イベント**: merge は `cell_deleted`（削除されたセル分）+ `cell_updated`（結合先セル）、split は `cell_updated` + `cell_added` のイベントを配信する。具体的なイベント型は既存の `postAiEvent` パターンに従う
+
+## 完了条件
+
+- [ ] `PATCH /api/custom/contents/{path}/cells` で `action: merge` が動作する
+- [ ] `PATCH /api/custom/contents/{path}/cells` で `action: split` が動作する
+- [ ] merge: 隣接する複数セルのソースが `\n` で連結され、1つのセルになる
+- [ ] split: 1つのセルが指定行で2つのセルに分割される
+- [ ] notebook_merge_cells MCPツールが正常に動作する
+- [ ] notebook_split_cell MCPツールが正常に動作する
+- [ ] AI編集モードの自動ロック/アンロックが動作する（NOTEBOOK_EDIT_TOOLS 登録）
+- [ ] リアルタイム同期イベントが配信される
+- [ ] 全ユニットテストが通過する
+- [ ] 型チェックが通過する
+
+## テスト計画
+
+### jupyter-server テスト（`test_cell_merge_split.py`）
+
+| カテゴリ | テスト内容 | 件数 |
+|---------|-----------|------|
+| merge 正常系 | 2セル結合、3セル以上結合、ソース連結確認 | 3 |
+| merge 異常系 | start > end、範囲外、1セル結合、セルタイプ混在 | 4 |
+| split 正常系 | 中間行分割、先頭行分割、最終行前分割 | 3 |
+| split 異常系 | 範囲外index、範囲外split_line | 2 |
+
+計: 12テスト
+
+### jupyter-mcp テスト（2ファイル合計）
+
+| カテゴリ | テスト内容 | 件数 |
+|---------|-----------|------|
+| merge 正常系 | 基本結合、レスポンス形式確認 | 2 |
+| merge 異常系 | 必須パラメータ欠如×3、パストラバーサル、APIエラー | 5 |
+| split 正常系 | 基本分割、レスポンス形式確認 | 2 |
+| split 異常系 | 必須パラメータ欠如×3、パストラバーサル、APIエラー | 5 |
+
+計: 14テスト
+
+**合計: 26テストケース**
+
+---
+
+## レビューステータス
+
+- [x] 計画レビュー完了
+- [ ] 実装完了
+- [ ] テスト完了

--- a/jupyter-mcp/src/jupyter-client/types.ts
+++ b/jupyter-mcp/src/jupyter-client/types.ts
@@ -180,13 +180,16 @@ export interface UpdateNotebookRequest {
   content: NotebookContent;
 }
 
-export type CellAction = 'add' | 'update' | 'delete' | 'reorder';
+export type CellAction = 'add' | 'update' | 'delete' | 'reorder' | 'merge' | 'split';
 
 export interface CellOperationRequest {
   action: CellAction;
   cell?: Partial<Cell>;
   index?: number;
   to_index?: number;
+  start_index?: number;
+  end_index?: number;
+  split_line?: number;
 }
 
 // =============================================================================
@@ -285,7 +288,9 @@ export interface AiEventBase {
     | 'cell_output'
     | 'cell_execute_end'
     | 'ai_edit_start'
-    | 'ai_edit_end';
+    | 'ai_edit_end'
+    | 'cells_merged'
+    | 'cell_split';
 }
 
 /**
@@ -400,6 +405,28 @@ export interface AiEditEndEvent extends AiEventBase {
 }
 
 /**
+ * セル結合イベント
+ * AIが notebook_merge_cells ツールを実行した際に配信される
+ */
+export interface CellsMergedEvent extends AiEventBase {
+  type: 'cells_merged';
+  notebook_path: string;
+  start_index: number;
+  end_index: number;
+}
+
+/**
+ * セル分割イベント
+ * AIが notebook_split_cell ツールを実行した際に配信される
+ */
+export interface CellSplitEvent extends AiEventBase {
+  type: 'cell_split';
+  notebook_path: string;
+  cell_index: number;
+  split_line: number;
+}
+
+/**
  * AI同期イベントの型定義
  */
 export type AiEvent =
@@ -411,7 +438,9 @@ export type AiEvent =
   | CellOutputEvent
   | CellExecuteEndEvent
   | AiEditStartEvent
-  | AiEditEndEvent;
+  | AiEditEndEvent
+  | CellsMergedEvent
+  | CellSplitEvent;
 
 export interface BroadcastEventResponse {
   broadcasted: boolean;

--- a/jupyter-mcp/src/tools/index.ts
+++ b/jupyter-mcp/src/tools/index.ts
@@ -42,6 +42,8 @@ import { executeNotebookExecuteCell } from './notebook-execute-cell.js';
 import { executeNotebookExecuteBatch } from './notebook-execute-batch.js';
 import { executeDataPreview } from './data-preview.js';
 import { executeFileRead } from './file-read.js';
+import { executeNotebookMergeCells } from './notebook-merge-cells.js';
+import { executeNotebookSplitCell } from './notebook-split-cell.js';
 
 const toolRegistry: ToolEntry<McpToolResult>[] = [
   {
@@ -647,6 +649,59 @@ const toolRegistry: ToolEntry<McpToolResult>[] = [
     },
     execute: executeFileRead,
   },
+  {
+    definition: {
+      name: 'notebook_merge_cells',
+      description:
+        'Merges adjacent cells in a notebook into a single cell. All cells in the range must be the same type (code or markdown). The merged cell source is the concatenation of all sources joined by newlines.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          notebook_path: {
+            type: 'string',
+            description: 'Notebook path (e.g., analysis.ipynb)',
+          },
+          start_index: {
+            type: 'number',
+            description: 'Start cell index (0-indexed, inclusive)',
+          },
+          end_index: {
+            type: 'number',
+            description: 'End cell index (0-indexed, inclusive). Must be greater than start_index',
+          },
+        },
+        required: ['notebook_path', 'start_index', 'end_index'],
+      },
+    },
+    execute: executeNotebookMergeCells,
+  },
+  {
+    definition: {
+      name: 'notebook_split_cell',
+      description:
+        'Splits a single cell in a notebook into two cells at the specified line. Lines before split_line go to the first cell, lines from split_line onward go to the second cell.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          notebook_path: {
+            type: 'string',
+            description: 'Notebook path (e.g., analysis.ipynb)',
+          },
+          cell_index: {
+            type: 'number',
+            description: 'Cell index to split (0-indexed)',
+          },
+          split_line: {
+            type: 'number',
+            description:
+              'Line number at which to split (1-indexed: line 1 means first line goes to first cell, remainder to second cell). Must be between 1 and total_lines-1',
+          },
+        },
+        required: ['notebook_path', 'cell_index', 'split_line'],
+      },
+    },
+    execute: executeNotebookSplitCell,
+  },
 ];
 
 /** ノートブック編集系ツール: 実行前後に ai_edit_start/end イベントを自動配信する */
@@ -658,6 +713,8 @@ const NOTEBOOK_EDIT_TOOLS = new Set([
   'notebook_execute_cell',
   'notebook_execute_batch',
   'notebook_reorder_cell',
+  'notebook_merge_cells',
+  'notebook_split_cell',
 ]);
 
 /**

--- a/jupyter-mcp/src/tools/notebook-merge-cells.ts
+++ b/jupyter-mcp/src/tools/notebook-merge-cells.ts
@@ -1,0 +1,62 @@
+/**
+ * notebook_merge_cells ツール実装
+ */
+
+import {
+  createSuccessResponse,
+  createErrorResponse,
+  extractErrorCode,
+  extractErrorMessage,
+  type McpResponse,
+} from '../utils/response-formatter.js';
+import { validateAndNormalizeNotebookPath, validateCellIndexParam } from '../utils/validation.js';
+import { jupyterClient } from '../jupyter-client/client.js';
+
+/**
+ * 隣接する複数セルを1つに結合する
+ */
+export async function executeNotebookMergeCells(args: Record<string, unknown>): Promise<McpResponse> {
+  const pathResult = validateAndNormalizeNotebookPath(args.notebook_path);
+  if ('error' in pathResult) {
+    return createErrorResponse(pathResult.error, 'VALIDATION_ERROR');
+  }
+  const validatedPath = pathResult.path;
+
+  const startIndexResult = validateCellIndexParam(args.start_index, 'start_index');
+  if ('error' in startIndexResult) {
+    return createErrorResponse(startIndexResult.error, 'VALIDATION_ERROR');
+  }
+  const startIndex = startIndexResult.index;
+
+  const endIndexResult = validateCellIndexParam(args.end_index, 'end_index');
+  if ('error' in endIndexResult) {
+    return createErrorResponse(endIndexResult.error, 'VALIDATION_ERROR');
+  }
+  const endIndex = endIndexResult.index;
+
+  try {
+    // REST API でセルを結合
+    await jupyterClient.operateCell(validatedPath, {
+      action: 'merge',
+      start_index: startIndex,
+      end_index: endIndex,
+    });
+
+    // AI同期イベントを配信（ブラウザにリアルタイム反映）
+    await jupyterClient.postAiEvent({
+      type: 'cells_merged',
+      notebook_path: validatedPath,
+      start_index: startIndex,
+      end_index: endIndex,
+    });
+
+    return createSuccessResponse({
+      notebook_path: validatedPath,
+      start_index: startIndex,
+      end_index: endIndex,
+      message: `ノートブック "${validatedPath}" のセル ${startIndex}〜${endIndex} を結合しました`,
+    });
+  } catch (error) {
+    return createErrorResponse(extractErrorMessage(error), extractErrorCode(error));
+  }
+}

--- a/jupyter-mcp/src/tools/notebook-split-cell.ts
+++ b/jupyter-mcp/src/tools/notebook-split-cell.ts
@@ -1,0 +1,66 @@
+/**
+ * notebook_split_cell ツール実装
+ */
+
+import {
+  createSuccessResponse,
+  createErrorResponse,
+  extractErrorCode,
+  extractErrorMessage,
+  type McpResponse,
+} from '../utils/response-formatter.js';
+import {
+  validateAndNormalizeNotebookPath,
+  validateCellIndexParam,
+  validatePositiveIntegerParam,
+} from '../utils/validation.js';
+import { jupyterClient } from '../jupyter-client/client.js';
+
+/**
+ * 1つのセルを指定行で2つに分割する
+ */
+export async function executeNotebookSplitCell(args: Record<string, unknown>): Promise<McpResponse> {
+  const pathResult = validateAndNormalizeNotebookPath(args.notebook_path);
+  if ('error' in pathResult) {
+    return createErrorResponse(pathResult.error, 'VALIDATION_ERROR');
+  }
+  const validatedPath = pathResult.path;
+
+  const cellIndexResult = validateCellIndexParam(args.cell_index);
+  if ('error' in cellIndexResult) {
+    return createErrorResponse(cellIndexResult.error, 'VALIDATION_ERROR');
+  }
+  const cellIndex = cellIndexResult.index;
+
+  const splitLineResult = validatePositiveIntegerParam(args.split_line, 'split_line');
+  if ('error' in splitLineResult) {
+    return createErrorResponse(splitLineResult.error, 'VALIDATION_ERROR');
+  }
+  const splitLine = splitLineResult.value;
+
+  try {
+    // REST API でセルを分割
+    await jupyterClient.operateCell(validatedPath, {
+      action: 'split',
+      index: cellIndex,
+      split_line: splitLine,
+    });
+
+    // AI同期イベントを配信（ブラウザにリアルタイム反映）
+    await jupyterClient.postAiEvent({
+      type: 'cell_split',
+      notebook_path: validatedPath,
+      cell_index: cellIndex,
+      split_line: splitLine,
+    });
+
+    return createSuccessResponse({
+      notebook_path: validatedPath,
+      cell_index: cellIndex,
+      split_line: splitLine,
+      message: `ノートブック "${validatedPath}" のセル ${cellIndex} を行 ${splitLine} で分割しました`,
+    });
+  } catch (error) {
+    return createErrorResponse(extractErrorMessage(error), extractErrorCode(error));
+  }
+}

--- a/jupyter-mcp/src/utils/validation.ts
+++ b/jupyter-mcp/src/utils/validation.ts
@@ -52,6 +52,19 @@ export function validateCellIndexParam(
 }
 
 /**
+ * 1以上の整数パラメータを検証し、数値を返す（split_line 等に使用）
+ */
+export function validatePositiveIntegerParam(value: unknown, paramName: string): { value: number } | { error: string } {
+  if (value === undefined || value === null) {
+    return { error: `${paramName} パラメータは必須です` };
+  }
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 1) {
+    return { error: `${paramName} パラメータは 1 以上の整数である必要があります` };
+  }
+  return { value };
+}
+
+/**
  * cell_index パラメータのバリデーション
  *
  * @param value - 検証する値

--- a/jupyter-mcp/tests/unit/tools/index.test.ts
+++ b/jupyter-mcp/tests/unit/tools/index.test.ts
@@ -89,6 +89,12 @@ vi.mock('../../../src/tools/data-preview.js', () => ({
 vi.mock('../../../src/tools/file-read.js', () => ({
   executeFileRead: vi.fn(async () => mockResponse('file_read')),
 }));
+vi.mock('../../../src/tools/notebook-merge-cells.js', () => ({
+  executeNotebookMergeCells: vi.fn(async () => mockResponse('notebook_merge_cells')),
+}));
+vi.mock('../../../src/tools/notebook-split-cell.js', () => ({
+  executeNotebookSplitCell: vi.fn(async () => mockResponse('notebook_split_cell')),
+}));
 
 beforeEach(() => {
   mockEmitAiEditStart.mockClear();
@@ -98,7 +104,7 @@ beforeEach(() => {
 describe('registerTools', () => {
   test('全ツールが登録されている', () => {
     const tools = registerTools();
-    expect(tools).toHaveLength(25);
+    expect(tools).toHaveLength(27);
 
     const expectedToolNames = [
       'workspace_create',
@@ -126,6 +132,8 @@ describe('registerTools', () => {
       'get_image',
       'data_preview',
       'file_read',
+      'notebook_merge_cells',
+      'notebook_split_cell',
     ];
 
     const toolNames = tools.map((t) => t.name);

--- a/jupyter-mcp/tests/unit/tools/notebook-merge-cells.test.ts
+++ b/jupyter-mcp/tests/unit/tools/notebook-merge-cells.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { executeNotebookMergeCells } from '../../../src/tools/notebook-merge-cells.js';
+
+// jupyterClient をモック
+vi.mock('../../../src/jupyter-client/client.js', () => ({
+  jupyterClient: {
+    operateCell: vi.fn(),
+    postAiEvent: vi.fn(),
+  },
+}));
+
+import { jupyterClient } from '../../../src/jupyter-client/client.js';
+
+describe('executeNotebookMergeCells', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('正常系', () => {
+    test('隣接する2セルを結合できる', async () => {
+      vi.mocked(jupyterClient.operateCell).mockResolvedValue(undefined);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookMergeCells({
+        notebook_path: 'analysis.ipynb',
+        start_index: 0,
+        end_index: 1,
+      });
+
+      // operateCell が merge アクションで呼ばれたことを確認
+      expect(jupyterClient.operateCell).toHaveBeenCalledWith('analysis.ipynb', {
+        action: 'merge',
+        start_index: 0,
+        end_index: 1,
+      });
+
+      // postAiEvent が cells_merged イベントで呼ばれたことを確認
+      expect(jupyterClient.postAiEvent).toHaveBeenCalledWith({
+        type: 'cells_merged',
+        notebook_path: 'analysis.ipynb',
+        start_index: 0,
+        end_index: 1,
+      });
+
+      expect(result.content[0].text).toContain('"success": true');
+      expect(result.content[0].text).toContain('"notebook_path": "analysis.ipynb"');
+      expect(result.content[0].text).toContain('"start_index": 0');
+      expect(result.content[0].text).toContain('"end_index": 1');
+    });
+
+    test('3セル以上を結合できる', async () => {
+      vi.mocked(jupyterClient.operateCell).mockResolvedValue(undefined);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookMergeCells({
+        notebook_path: 'analysis.ipynb',
+        start_index: 0,
+        end_index: 3,
+      });
+
+      expect(jupyterClient.operateCell).toHaveBeenCalledWith('analysis.ipynb', {
+        action: 'merge',
+        start_index: 0,
+        end_index: 3,
+      });
+
+      expect(result.content[0].text).toContain('"success": true');
+      expect(result.content[0].text).toContain('"start_index": 0');
+      expect(result.content[0].text).toContain('"end_index": 3');
+    });
+  });
+
+  describe('異常系 - バリデーションエラー', () => {
+    test('notebook_path 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookMergeCells({
+        start_index: 0,
+        end_index: 1,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('notebook_path');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('start_index 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookMergeCells({
+        notebook_path: 'analysis.ipynb',
+        end_index: 1,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('start_index');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('end_index 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookMergeCells({
+        notebook_path: 'analysis.ipynb',
+        start_index: 0,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('end_index');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('パストラバーサル攻撃 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookMergeCells({
+        notebook_path: '../../../etc/passwd',
+        start_index: 0,
+        end_index: 1,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('異常系 - API エラー', () => {
+    test('セルタイプ混在 => CELL_TYPE_MISMATCH エラー', async () => {
+      const error = new Error('セルタイプが混在しています');
+      (error as Record<string, unknown>).code = 'CELL_TYPE_MISMATCH';
+      vi.mocked(jupyterClient.operateCell).mockRejectedValue(error);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookMergeCells({
+        notebook_path: 'analysis.ipynb',
+        start_index: 0,
+        end_index: 1,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('CELL_TYPE_MISMATCH');
+    });
+  });
+});

--- a/jupyter-mcp/tests/unit/tools/notebook-split-cell.test.ts
+++ b/jupyter-mcp/tests/unit/tools/notebook-split-cell.test.ts
@@ -1,0 +1,140 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { executeNotebookSplitCell } from '../../../src/tools/notebook-split-cell.js';
+
+// jupyterClient をモック
+vi.mock('../../../src/jupyter-client/client.js', () => ({
+  jupyterClient: {
+    operateCell: vi.fn(),
+    postAiEvent: vi.fn(),
+  },
+}));
+
+import { jupyterClient } from '../../../src/jupyter-client/client.js';
+
+describe('executeNotebookSplitCell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('正常系', () => {
+    test('セルを指定行で分割できる', async () => {
+      vi.mocked(jupyterClient.operateCell).mockResolvedValue(undefined);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookSplitCell({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 0,
+        split_line: 2,
+      });
+
+      // operateCell が split アクションで呼ばれたことを確認
+      expect(jupyterClient.operateCell).toHaveBeenCalledWith('analysis.ipynb', {
+        action: 'split',
+        index: 0,
+        split_line: 2,
+      });
+
+      // postAiEvent が cell_split イベントで呼ばれたことを確認
+      expect(jupyterClient.postAiEvent).toHaveBeenCalledWith({
+        type: 'cell_split',
+        notebook_path: 'analysis.ipynb',
+        cell_index: 0,
+        split_line: 2,
+      });
+
+      expect(result.content[0].text).toContain('"success": true');
+      expect(result.content[0].text).toContain('"notebook_path": "analysis.ipynb"');
+      expect(result.content[0].text).toContain('"cell_index": 0');
+      expect(result.content[0].text).toContain('"split_line": 2');
+    });
+
+    test('split_line=1 で先頭行のみを前半にできる', async () => {
+      vi.mocked(jupyterClient.operateCell).mockResolvedValue(undefined);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookSplitCell({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 1,
+        split_line: 1,
+      });
+
+      expect(jupyterClient.operateCell).toHaveBeenCalledWith('analysis.ipynb', {
+        action: 'split',
+        index: 1,
+        split_line: 1,
+      });
+
+      expect(result.content[0].text).toContain('"success": true');
+      expect(result.content[0].text).toContain('"cell_index": 1');
+      expect(result.content[0].text).toContain('"split_line": 1');
+    });
+  });
+
+  describe('異常系 - バリデーションエラー', () => {
+    test('notebook_path 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookSplitCell({
+        cell_index: 0,
+        split_line: 1,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('notebook_path');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('cell_index 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookSplitCell({
+        notebook_path: 'analysis.ipynb',
+        split_line: 1,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('cell_index');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('split_line 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookSplitCell({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 0,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('split_line');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('パストラバーサル攻撃 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookSplitCell({
+        notebook_path: '../../../etc/passwd',
+        cell_index: 0,
+        split_line: 1,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('異常系 - API エラー', () => {
+    test('範囲外の cell_index => INVALID_CELL_INDEX エラー', async () => {
+      const error = new Error('セルインデックスが不正です: 999');
+      (error as Record<string, unknown>).code = 'INVALID_CELL_INDEX';
+      vi.mocked(jupyterClient.operateCell).mockRejectedValue(error);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookSplitCell({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 999,
+        split_line: 1,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('INVALID_CELL_INDEX');
+    });
+  });
+});

--- a/jupyter-server/extensions/custom_api/handlers.py
+++ b/jupyter-server/extensions/custom_api/handlers.py
@@ -743,6 +743,110 @@ class ContentsCellsHandler(BaseCustomHandler):
                 insert_index = min(to_index, len(cells))
                 cells.insert(insert_index, cell_to_move)
 
+            elif action == "merge":
+                start_index = body.get("start_index")
+                end_index = body.get("end_index")
+
+                if start_index is None or end_index is None:
+                    self.write_error_response("VALIDATION_ERROR", "start_index and end_index are required", 400)
+                    return
+                if not isinstance(start_index, int) or not isinstance(end_index, int):
+                    self.write_error_response("VALIDATION_ERROR", "start_index and end_index must be integers", 400)
+                    return
+                if start_index >= end_index:
+                    self.write_error_response(
+                        "VALIDATION_ERROR",
+                        f"start_index ({start_index}) must be less than end_index ({end_index})",
+                        400,
+                    )
+                    return
+                if start_index < 0 or end_index >= len(cells):
+                    self.write_error_response(
+                        "VALIDATION_ERROR",
+                        f"Index out of range: start_index={start_index}, end_index={end_index}, total={len(cells)}",
+                        400,
+                    )
+                    return
+
+                # セルタイプ混在チェック
+                cell_types = {cells[i]["cell_type"] for i in range(start_index, end_index + 1)}
+                if len(cell_types) > 1:
+                    self.write_error_response(
+                        "CELL_TYPE_MISMATCH",
+                        "Cannot merge cells of different types",
+                        400,
+                    )
+                    return
+
+                # ソースを \n で連結（末尾改行の重複を避ける）
+                merged_source = "\n".join(
+                    cells[i].get("source", "").rstrip("\n") for i in range(start_index, end_index + 1)
+                )
+                cell_type = cells[start_index]["cell_type"]
+                merged_cell = {
+                    "cell_type": cell_type,
+                    "source": merged_source,
+                    "metadata": cells[start_index].get("metadata", {}),
+                }
+                if cell_type == "code":
+                    merged_cell["outputs"] = []
+                    merged_cell["execution_count"] = None
+
+                # 先頭セルを置換し、残りを削除
+                cells[start_index] = merged_cell
+                del cells[start_index + 1 : end_index + 1]
+
+            elif action == "split":
+                split_index = body.get("index")
+                split_line = body.get("split_line")
+
+                if split_index is None or split_line is None:
+                    self.write_error_response("VALIDATION_ERROR", "index and split_line are required", 400)
+                    return
+                if not isinstance(split_index, int) or not isinstance(split_line, int):
+                    self.write_error_response("VALIDATION_ERROR", "index and split_line must be integers", 400)
+                    return
+                if split_index < 0 or split_index >= len(cells):
+                    self.write_error_response("INVALID_CELL_INDEX", f"Invalid index: {split_index}", 400)
+                    return
+
+                source = cells[split_index].get("source", "")
+                source_lines = source.split("\n")
+                total_lines = len(source_lines)
+
+                if split_line < 1 or split_line >= total_lines:
+                    self.write_error_response(
+                        "VALIDATION_ERROR",
+                        f"split_line ({split_line}) must be between 1 and {total_lines - 1}",
+                        400,
+                    )
+                    return
+
+                cell_type = cells[split_index]["cell_type"]
+                metadata = cells[split_index].get("metadata", {})
+
+                first_half = "\n".join(source_lines[:split_line])
+                second_half = "\n".join(source_lines[split_line:])
+
+                first_cell = {
+                    "cell_type": cell_type,
+                    "source": first_half,
+                    "metadata": metadata,
+                }
+                second_cell = {
+                    "cell_type": cell_type,
+                    "source": second_half,
+                    "metadata": {},
+                }
+                if cell_type == "code":
+                    first_cell["outputs"] = []
+                    first_cell["execution_count"] = None
+                    second_cell["outputs"] = []
+                    second_cell["execution_count"] = None
+
+                cells[split_index] = first_cell
+                cells.insert(split_index + 1, second_cell)
+
             else:
                 self.write_error_response("VALIDATION_ERROR", f"Unknown action: {action}", 400)
                 return

--- a/jupyter-server/tests/test_cell_merge_split.py
+++ b/jupyter-server/tests/test_cell_merge_split.py
@@ -1,0 +1,378 @@
+"""ContentsCellsHandler の merge/split アクションのユニットテスト
+
+handlers.py の ContentsCellsHandler.patch() に merge/split アクションを追加する。
+ハンドラーの処理ロジックを直接インポートしてモックでテストする。
+
+テスト対象のアクションがまだ存在しないため（TDD Red フェーズ）、
+ハンドラーの存在確認とアクション実行結果のテストを行う。
+"""
+
+import importlib.util
+import sys
+import types as _types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_ext_dir = Path(__file__).resolve().parent.parent / "extensions"
+
+# --- 1. 重い依存のモック ---
+for _mod_name in ("pandas", "sqlalchemy", "sqlalchemy.exc", "tornado", "tornado.web"):
+    if _mod_name not in sys.modules:
+        _m = _types.ModuleType(_mod_name)
+        if _mod_name == "tornado.web":
+            _m.authenticated = lambda f: f
+        sys.modules[_mod_name] = _m
+
+# --- 2. custom_api パッケージ構造の構築 ---
+if "custom_api" not in sys.modules:
+    _pkg = _types.ModuleType("custom_api")
+    _pkg.__path__ = [str(_ext_dir / "custom_api")]
+    _pkg.__package__ = "custom_api"
+    sys.modules["custom_api"] = _pkg
+
+# base モジュールのモック
+if "custom_api.base" not in sys.modules:
+    _base_mock = _types.ModuleType("custom_api.base")
+    _base_mock.__package__ = "custom_api"
+    _base_mock.BaseCustomHandler = type("BaseCustomHandler", (), {})
+    _base_mock.resolve_workspace_dir = lambda *a, **kw: None
+    _base_mock.validate_timeout = lambda *a, **kw: (30, None)
+    _base_mock.validate_workspace_id = lambda *a, **kw: None
+    _base_mock.workspace_contents_path = lambda *a, **kw: ""
+    _base_mock.utc_now_iso = lambda: "2026-01-01T00:00:00Z"
+    _base_mock.WORKSPACE_ROOT_DIR = "/home/jovyan/work/workspaces/sample"
+    _base_mock.WORKSPACE_PATH_PREFIX = "workspaces/sample"
+    _base_mock.JUPYTER_ROOT_DIR = "/home/jovyan/work"
+    _base_mock.validate_kernel_name = lambda *a, **kw: None
+    sys.modules["custom_api.base"] = _base_mock
+
+# ai_events モジュールのモック
+if "custom_api.ai_events" not in sys.modules:
+    _ai_events_mock = _types.ModuleType("custom_api.ai_events")
+    _ai_events_mock.__package__ = "custom_api"
+    _ai_events_mock.AiEventsWebSocketHandler = type("AiEventsWebSocketHandler", (), {})
+    _ai_events_mock.AiEventsPostHandler = type("AiEventsPostHandler", (), {})
+    sys.modules["custom_api.ai_events"] = _ai_events_mock
+
+# code_validator モジュール（実際にロード — 純粋関数のため）
+if "custom_api.code_validator" not in sys.modules:
+    _cv_path = _ext_dir / "custom_api" / "code_validator.py"
+    _cv_spec = importlib.util.spec_from_file_location(
+        "custom_api.code_validator", _cv_path, submodule_search_locations=[]
+    )
+    _cv_mod = importlib.util.module_from_spec(_cv_spec)
+    _cv_mod.__package__ = "custom_api"
+    sys.modules["custom_api.code_validator"] = _cv_mod
+    _cv_spec.loader.exec_module(_cv_mod)
+
+# kernel_executor モジュールのモック
+if "custom_api.kernel_executor" not in sys.modules:
+    _ke_mock = _types.ModuleType("custom_api.kernel_executor")
+    _ke_mock.__package__ = "custom_api"
+    _ke_mock.KernelExecutor = MagicMock
+    sys.modules["custom_api.kernel_executor"] = _ke_mock
+
+# session_handlers モジュールのモック
+if "custom_api.session_handlers" not in sys.modules:
+    _sh_mock = _types.ModuleType("custom_api.session_handlers")
+    _sh_mock.__package__ = "custom_api"
+    _sh_mock.CustomSessionsHandler = type("CustomSessionsHandler", (), {})
+    _sh_mock.get_kernel_workspace = lambda *a: None
+    _sh_mock.unregister_kernel = lambda *a: None
+    sys.modules["custom_api.session_handlers"] = _sh_mock
+
+# sql_handlers モジュールのモック
+if "custom_api.sql_handlers" not in sys.modules:
+    _sql_mock = _types.ModuleType("custom_api.sql_handlers")
+    _sql_mock.__package__ = "custom_api"
+    _sql_mock.SqlExecuteHandler = type("SqlExecuteHandler", (), {})
+    _sql_mock.SqlExportHandler = type("SqlExportHandler", (), {})
+    sys.modules["custom_api.sql_handlers"] = _sql_mock
+
+# workspace_handlers モジュールのモック
+if "custom_api.workspace_handlers" not in sys.modules:
+    _wh_mock = _types.ModuleType("custom_api.workspace_handlers")
+    _wh_mock.__package__ = "custom_api"
+    _wh_mock.WorkspaceHandler = type("WorkspaceHandler", (), {})
+    _wh_mock.WorkspacesHandler = type("WorkspacesHandler", (), {})
+    _wh_mock.WorkspaceSummarizeHandler = type("WorkspaceSummarizeHandler", (), {})
+    sys.modules["custom_api.workspace_handlers"] = _wh_mock
+
+# --- 3. handlers モジュールをロード ---
+_module_path = _ext_dir / "custom_api" / "handlers.py"
+_handlers_spec = importlib.util.spec_from_file_location(
+    "custom_api.handlers",
+    _module_path,
+    submodule_search_locations=[],
+)
+_handlers = importlib.util.module_from_spec(_handlers_spec)
+_handlers.__package__ = "custom_api"
+sys.modules["custom_api.handlers"] = _handlers
+_handlers_spec.loader.exec_module(_handlers)
+
+validate_path = _handlers.validate_path
+ContentsCellsHandler = _handlers.ContentsCellsHandler
+
+
+# ============================================================
+# ヘルパー: ContentsCellsHandler のモックインスタンスを作成
+# ============================================================
+
+
+def _make_handler(cells: list[dict], path: str = "workspaces/sample/ws-001/test.ipynb"):
+    """ContentsCellsHandler のモックを作成し、patch() を呼べるようにする"""
+    handler = MagicMock(spec=ContentsCellsHandler)
+
+    model = {
+        "type": "notebook",
+        "content": {"cells": [dict(c) for c in cells]},
+    }
+
+    handler.get_json_body = MagicMock()
+    handler.contents_manager = MagicMock()
+    handler.contents_manager.get = AsyncMock(return_value=model)
+    handler.contents_manager.save = AsyncMock()
+
+    _responses = []
+    handler.write_success = MagicMock(side_effect=lambda d: _responses.append(("success", d)))
+    handler.write_error_response = MagicMock(
+        side_effect=lambda code, msg, status: _responses.append(("error", code, msg, status))
+    )
+    handler._responses = _responses
+    handler._model = model
+
+    return handler, path
+
+
+async def _call_patch(handler, path, body):
+    """handler.patch() をバインドして呼び出す"""
+    handler.get_json_body.return_value = body
+    await ContentsCellsHandler.patch(handler, path)
+
+
+# ============================================================
+# merge 正常系テスト
+# ============================================================
+
+
+class TestMergeNormal:
+    """merge アクションの正常系テスト"""
+
+    @pytest.mark.asyncio
+    async def test_merge_two_code_cells(self):
+        """2つのコードセルを結合: ソースが \\n 区切りで連結される"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1", "outputs": [], "execution_count": None},
+            {"cell_type": "code", "source": "b = 2", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "merge", "start_index": 0, "end_index": 1})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "success"
+
+        # save が呼ばれたことを確認
+        handler.contents_manager.save.assert_called_once()
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        merged_cells = saved_model["content"]["cells"]
+        assert len(merged_cells) == 1
+        assert merged_cells[0]["source"] == "a = 1\nb = 2"
+        assert merged_cells[0]["cell_type"] == "code"
+
+    @pytest.mark.asyncio
+    async def test_merge_three_code_cells(self):
+        """3つ以上のコードセルを結合"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1", "outputs": [], "execution_count": None},
+            {"cell_type": "code", "source": "b = 2", "outputs": [], "execution_count": None},
+            {"cell_type": "code", "source": "c = 3", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "merge", "start_index": 0, "end_index": 2})
+
+        assert handler._responses[0][0] == "success"
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        merged_cells = saved_model["content"]["cells"]
+        assert len(merged_cells) == 1
+        assert merged_cells[0]["source"] == "a = 1\nb = 2\nc = 3"
+
+    @pytest.mark.asyncio
+    async def test_merge_two_markdown_cells(self):
+        """2つの Markdown セルを結合"""
+        cells = [
+            {"cell_type": "markdown", "source": "# Title"},
+            {"cell_type": "markdown", "source": "Some text"},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "merge", "start_index": 0, "end_index": 1})
+
+        assert handler._responses[0][0] == "success"
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        merged_cells = saved_model["content"]["cells"]
+        assert len(merged_cells) == 1
+        assert merged_cells[0]["source"] == "# Title\nSome text"
+        assert merged_cells[0]["cell_type"] == "markdown"
+
+
+# ============================================================
+# merge 異常系テスト
+# ============================================================
+
+
+class TestMergeError:
+    """merge アクションの異常系テスト"""
+
+    @pytest.mark.asyncio
+    async def test_merge_start_greater_than_end(self):
+        """start_index > end_index でエラー"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1", "outputs": [], "execution_count": None},
+            {"cell_type": "code", "source": "b = 2", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "merge", "start_index": 1, "end_index": 0})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "error"
+
+    @pytest.mark.asyncio
+    async def test_merge_out_of_range(self):
+        """end_index が範囲外でエラー"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1", "outputs": [], "execution_count": None},
+            {"cell_type": "code", "source": "b = 2", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "merge", "start_index": 0, "end_index": 5})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "error"
+
+    @pytest.mark.asyncio
+    async def test_merge_single_cell(self):
+        """start_index == end_index（セル数1）で結合不可エラー"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "merge", "start_index": 0, "end_index": 0})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "error"
+
+    @pytest.mark.asyncio
+    async def test_merge_mixed_cell_types(self):
+        """セルタイプが混在している場合にエラー"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1", "outputs": [], "execution_count": None},
+            {"cell_type": "markdown", "source": "# Title"},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "merge", "start_index": 0, "end_index": 1})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "error"
+
+
+# ============================================================
+# split 正常系テスト
+# ============================================================
+
+
+class TestSplitNormal:
+    """split アクションの正常系テスト"""
+
+    @pytest.mark.asyncio
+    async def test_split_at_middle_line(self):
+        """セルを中間行で分割"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1\nb = 2\nc = 3", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "split", "index": 0, "split_line": 1})
+
+        assert handler._responses[0][0] == "success"
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        split_cells = saved_model["content"]["cells"]
+        assert len(split_cells) == 2
+        assert split_cells[0]["source"] == "a = 1"
+        assert split_cells[1]["source"] == "b = 2\nc = 3"
+        assert split_cells[0]["cell_type"] == "code"
+        assert split_cells[1]["cell_type"] == "code"
+
+    @pytest.mark.asyncio
+    async def test_split_at_first_line(self):
+        """先頭行（split_line=0）で分割: 前半が空"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1\nb = 2", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        # split_line=0 は「0行目の後で分割」ではなく「0行目の前で分割」
+        # つまり前半が空、後半が全行
+        # → 実装仕様に合わせる: split_line は「前半に含む行数」とする
+        # split_line=1 なら前半は1行目まで、split_line=0 は無効
+        # 仕様: split_line は分割位置（この行の前で分割）
+        # split_line=1 → 0行目が前半、1行目以降が後半
+        await _call_patch(handler, path, {"action": "split", "index": 0, "split_line": 1})
+
+        assert handler._responses[0][0] == "success"
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        split_cells = saved_model["content"]["cells"]
+        assert len(split_cells) == 2
+        assert split_cells[0]["source"] == "a = 1"
+        assert split_cells[1]["source"] == "b = 2"
+
+    @pytest.mark.asyncio
+    async def test_split_at_last_line_minus_one(self):
+        """最終行の1つ前で分割"""
+        cells = [
+            {"cell_type": "markdown", "source": "# Title\nParagraph 1\nParagraph 2"},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "split", "index": 0, "split_line": 2})
+
+        assert handler._responses[0][0] == "success"
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        split_cells = saved_model["content"]["cells"]
+        assert len(split_cells) == 2
+        assert split_cells[0]["source"] == "# Title\nParagraph 1"
+        assert split_cells[1]["source"] == "Paragraph 2"
+        assert split_cells[0]["cell_type"] == "markdown"
+        assert split_cells[1]["cell_type"] == "markdown"
+
+
+# ============================================================
+# split 異常系テスト
+# ============================================================
+
+
+class TestSplitError:
+    """split アクションの異常系テスト"""
+
+    @pytest.mark.asyncio
+    async def test_split_out_of_range_index(self):
+        """範囲外のセルインデックスでエラー"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1\nb = 2", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "split", "index": 5, "split_line": 1})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "error"
+
+    @pytest.mark.asyncio
+    async def test_split_out_of_range_split_line(self):
+        """範囲外の split_line でエラー（行数以上の値）"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1\nb = 2", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        # ソースは2行なので split_line は 1 まで有効（split_line=2 は最終行の後 → 後半が空）
+        # split_line >= 行数はエラーとする
+        await _call_patch(handler, path, {"action": "split", "index": 0, "split_line": 10})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "error"


### PR DESCRIPTION
## Summary
- jupyter-server: `PATCH /cells` に `merge`/`split` アクションを追加（セルタイプ混在チェック、出力リセット対応）
- jupyter-mcp: `notebook_merge_cells`、`notebook_split_cell` MCPツールを新規作成
- AI編集モード自動ロック対応（`NOTEBOOK_EDIT_TOOLS` 登録）
- リアルタイム同期イベント（`cells_merged`、`cell_split`）の配信
- jupyter-server 12テスト + jupyter-mcp 14テスト = 合計26テスト追加
- `split_line` の indexing を要件定義で 0-indexed→1-indexed に修正（実装と一致）

## Test plan
- [x] jupyter-server ユニットテスト（merge 正常系3 + 異常系4、split 正常系3 + 異常系2）
- [x] jupyter-mcp ユニットテスト（merge 正常系2 + 異常系5、split 正常系2 + 異常系5）
- [x] 型チェック通過
- [x] 全387テスト通過（既存テストへの影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
