### PR TITLE
feat: ローカル lint/format チェックを追加 + complete-task 自動修正

### DIFF
--- a/.claude/commands/custom-auto-dev.md
+++ b/.claude/commands/custom-auto-dev.md
@@ -166,6 +166,7 @@ Agent ツールでサブエージェントを起動してください。
 ## 手順
 
 `.claude/rules/tdd.md` を読み、「Red フェーズ」の手順に従ってテストを準備してください。
+lint 失敗時は `.claude/rules/lint.md` に従うこと。
 テスト実行コマンド: `scripts/test.sh --rebuild {コンポーネント名}`
 
 ## 報告
@@ -204,6 +205,7 @@ Agent ツールでサブエージェントを起動してください。
 ## 実装手順
 
 `.claude/rules/tdd.md` を読み、「Green フェーズ」の手順に従って実装してください。
+lint 失敗時は `.claude/rules/lint.md` に従うこと。
 テストが通るまで最大 5 回繰り返すこと。
 実装に関係のないファイルを変更しないこと。
 
@@ -259,6 +261,7 @@ Agent ツールでサブエージェントを起動し、レビュー指摘に�
 
 制約:
 - `.claude/rules/tdd.md` の原則に従うこと
+- lint 失敗時は `.claude/rules/lint.md` に従うこと
 - 機能の追加・変更を行わない（リファクタリングのみ）
 - テストが通るまで最大 3 回繰り返す
 
@@ -295,7 +298,7 @@ Agent ツール（subagent_type: `code-reviewer`, model: `opus`）でレビュ�
 - レビューの REJECT 理由と修正指示
 - テスト実行コマンド: `scripts/test.sh --rebuild {コンポーネント名}`
 
-制約: テストコードを変更しない、指摘箇所のみ修正
+制約: テストコードを変更しない、指摘箇所のみ修正、lint 失敗時は `.claude/rules/lint.md` に従うこと
 
 修正後、再度ステップ 2e（レビュー）を実行してください。
 

--- a/.claude/commands/custom-complete-task.md
+++ b/.claude/commands/custom-complete-task.md
@@ -30,6 +30,7 @@ dev ブランチ上にいる場合は、対象タスクの feature ブランチ�
 
 `scripts/test.sh --rebuild {対象コンポーネント名}` を実行してください。
 `.claude/rules/rebuild-before-test.md` に従うこと。
+lint 失敗時は `.claude/rules/lint.md` に従うこと。
 
 ## 4. 完了検証
 

--- a/.claude/commands/custom-refactor.md
+++ b/.claude/commands/custom-refactor.md
@@ -108,6 +108,7 @@ git diff --name-only HEAD~1
 
 `scripts/test.sh --rebuild {対象コンポーネント名}` を実行してください。
 `.claude/rules/rebuild-before-test.md` に従うこと。
+lint 失敗時は `.claude/rules/lint.md` に従うこと。
 
 ### 4.3.1 シェルスクリプトの動作確認（対象に `*.sh` が含まれる場合）
 

--- a/.claude/commands/custom-report-test-failure.md
+++ b/.claude/commands/custom-report-test-failure.md
@@ -33,9 +33,9 @@
 
 ### 手順1: テストを1回だけ実行し、出力をファイルに保存
 
-scripts/test.sh --integration --rebuild --health {コンポーネント名} 2>&1 | tee /tmp/test-output.log
+scripts/test.sh --integration --rebuild --health --no-lint {コンポーネント名} 2>&1 | tee /tmp/test-output.log
 
-（全コンポーネントの場合は引数なし: scripts/test.sh --integration --rebuild --health 2>&1 | tee /tmp/test-output.log）
+（全コンポーネントの場合は引数なし: scripts/test.sh --integration --rebuild --health --no-lint 2>&1 | tee /tmp/test-output.log）
 
 **重要: テストは1回しか実行しないこと。解析に必要な情報はすべて /tmp/test-output.log から Read ツールや Grep ツールで取得すること。**
 

--- a/.claude/commands/custom-resolve-issues.md
+++ b/.claude/commands/custom-resolve-issues.md
@@ -145,6 +145,8 @@ Phase 1.4 の見積もりに基づいて修正を実装してください。
 
 #### 3.2 テスト実行
 
+lint 失敗時は `.claude/rules/lint.md` に従うこと。
+
 ```bash
 scripts/test.sh --health {対象コンポーネント名}
 ```
@@ -193,7 +195,7 @@ Closes #{Issue番号1}, #{Issue番号2}, ...
 
 ### 4.1 最終テスト
 
-全コンポーネントの最終テストを実行してください：
+全コンポーネントの最終テストを実行してください。lint 失敗時は `.claude/rules/lint.md` に従うこと。
 
 ```bash
 scripts/test.sh --health

--- a/.claude/commands/custom-start-fix.md
+++ b/.claude/commands/custom-start-fix.md
@@ -80,6 +80,7 @@ Issue #{Issue番号} の修正を実装してください。
 - 修正方針から逸脱しない
 - 影響範囲外のファイルを不必要に変更しない
 - `.claude/rules/tdd.md` を読み、その原則に従うこと
+- lint 失敗時は `.claude/rules/lint.md` に従うこと
 - テスト実行コマンド: `scripts/test.sh --rebuild {コンポーネント名}`
 - テストが通るまで最大 5 回繰り返すこと
 

--- a/.claude/commands/custom-start-task.md
+++ b/.claude/commands/custom-start-task.md
@@ -89,6 +89,7 @@ Agent ツールでサブエージェントを起動してください。
 ## 手順
 
 `.claude/rules/tdd.md` を読み、「Red フェーズ」の手順に従ってテストを準備してください。
+lint 失敗時は `.claude/rules/lint.md` に従うこと。
 テスト実行コマンド: `scripts/test.sh --rebuild {コンポーネント名}`
 
 ## 報告
@@ -129,6 +130,7 @@ Agent ツールでサブエージェントを起動してください。
 ## 実装手順
 
 `.claude/rules/tdd.md` を読み、「Green フェーズ」の手順に従って実装してください。
+lint 失敗時は `.claude/rules/lint.md` に従うこと。
 テストが通るまで最大 5 回繰り返すこと。
 実装に関係のないファイルを変更しないこと。
 

--- a/.claude/rules/lint.md
+++ b/.claude/rules/lint.md
@@ -1,0 +1,25 @@
+# Lint ルール
+
+## lint の実行タイミング
+
+`scripts/test.sh` はデフォルトで lint を含む（`--no-lint` でスキップ可能）。
+カスタムコマンド（`start-task`, `complete-task`, `refactor` 等）は `test.sh` 経由で自動的に lint が走る。
+
+単独実行: `scripts/lint.sh [COMPONENT]`
+
+## lint 失敗時の対応
+
+lint が失敗した場合、Claude は以下の手順で対応すること:
+
+1. `lint.sh` のエラー出力から問題箇所と原因を読み取る
+2. 該当ファイルを修正する（`--fix` による自動修正は使わない）
+3. `scripts/lint.sh {対象コンポーネント}` を再実行して修正を確認する
+4. lint が通ったら、中断していたテスト（`scripts/test.sh`）を再実行する
+
+最大 3 回修正を試みても解決しない場合は、エラー内容をユーザーに報告して判断を仰ぐ。
+
+## 禁止事項
+
+- lint 失敗を無視してテストやコミットに進むこと
+- `prettier --write` や `ruff format`（修正モード）を実行すること — 修正は Claude が手動で行う
+- `--no-lint` を明示的な理由なく使うこと

--- a/.claude/rules/scripts.md
+++ b/.claude/rules/scripts.md
@@ -7,8 +7,10 @@
 
 | スクリプト | 用途 | 例 |
 |-----------|------|-----|
-| `scripts/test.sh [COMPONENT]` | 型チェック + テスト | `scripts/test.sh jupyter-mcp` |
-| `scripts/test.sh --rebuild [COMPONENT]` | リビルド + テスト（MCP/Docker 自動判定） | `scripts/test.sh --rebuild jupyter-mcp` |
+| `scripts/lint.sh [COMPONENT]` | lint / format チェック（検出のみ） | `scripts/lint.sh jupyter-mcp` |
+| `scripts/test.sh [COMPONENT]` | lint + 型チェック + テスト | `scripts/test.sh jupyter-mcp` |
+| `scripts/test.sh --no-lint [COMPONENT]` | 型チェック + テスト（lint スキップ） | `scripts/test.sh --no-lint jupyter-mcp` |
+| `scripts/test.sh --rebuild [COMPONENT]` | リビルド + lint + テスト（MCP/Docker 自動判定） | `scripts/test.sh --rebuild jupyter-mcp` |
 | `scripts/test.sh --integration [COMPONENT]` | 統合テスト（Docker 環境必要） | `scripts/test.sh --integration jupyter-mcp` |
 | `scripts/smoke-test.sh` | Docker 環境のスモークテスト | `scripts/smoke-test.sh` |
 | `scripts/check-freshness.sh` | Docker 環境の鮮度チェック | `scripts/check-freshness.sh` |
@@ -29,11 +31,16 @@
 ## よく使うパターン
 
 ```bash
-# リビルド + テスト（推奨: MCP/Docker を自動判定）
+# lint / format チェック（検出のみ、CI と同じルール）
+scripts/lint.sh                           # 全対象
+scripts/lint.sh jupyter-mcp               # 特定コンポーネント
+scripts/lint.sh document-server scripts   # 複数指定
+
+# リビルド + テスト（推奨: MCP/Docker を自動判定、lint 込み）
 scripts/test.sh --rebuild jupyter-mcp
 scripts/test.sh --rebuild document-server
 
-# コード変更後のテスト（リビルドなし）
+# コード変更後のテスト（リビルドなし、lint 込み）
 scripts/test.sh jupyter-mcp
 
 # MCP サーバーのリビルド（コード変更を反映）

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Prettier check
         if: needs.changes.outputs.code_changed == 'true'
-        run: npx prettier --check "jupyter-mcp/src/**/*.ts" "document-mcp/src/**/*.ts" "packages/mcp-shared/src/**/*.ts"
+        run: scripts/lint.sh jupyter-mcp document-mcp mcp-shared
 
       - name: Build mcp-shared
         if: needs.changes.outputs.code_changed == 'true'
@@ -110,19 +110,9 @@ jobs:
           pip install -e "document-server[dev]" types-PyYAML
           pip install pytest pytest-asyncio sqlparse
 
-      - name: Ruff format check
+      - name: Ruff format + lint check
         if: needs.changes.outputs.code_changed == 'true'
-        run: |
-          ruff format --check document-server/src/ document-server/tests/
-          ruff format --check jupyter-server/extensions/ jupyter-server/tests/
-          ruff format --check scripts/*.py scripts/lib/*.py
-
-      - name: Ruff lint
-        if: needs.changes.outputs.code_changed == 'true'
-        run: |
-          ruff check document-server/src/ document-server/tests/
-          ruff check jupyter-server/extensions/ jupyter-server/tests/
-          ruff check scripts/*.py scripts/lib/*.py
+        run: scripts/lint.sh document-server jupyter-server scripts
 
       - name: Mypy (document-server)
         if: needs.changes.outputs.code_changed == 'true'

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,169 @@
+#!/bin/bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [OPTIONS] [COMPONENT...]
+
+コードの lint / format チェックを実行します（検出のみ、自動修正なし）。
+CI と同じルールをローカルで事前チェックできます。
+
+COMPONENT:
+  jupyter-mcp       Jupyter MCP サーバー (prettier)
+  document-mcp      Document MCP サーバー (prettier)
+  mcp-shared        MCP 共有パッケージ (prettier)
+  document-server   Document サーバー (ruff)
+  jupyter-server    Jupyter サーバー (ruff)
+  scripts           運用スクリプト (ruff)
+  (省略時は全対象)
+
+OPTIONS:
+  -h, --help      このヘルプを表示
+
+Examples:
+  $(basename "$0")                      # 全対象をチェック
+  $(basename "$0") jupyter-mcp          # jupyter-mcp のみ
+  $(basename "$0") document-server      # document-server のみ
+EOF
+}
+
+# ── Target definitions ──
+
+TS_COMPONENTS=(jupyter-mcp document-mcp mcp-shared)
+PY_COMPONENTS=(document-server jupyter-server scripts)
+ALL_COMPONENTS=("${TS_COMPONENTS[@]}" "${PY_COMPONENTS[@]}")
+
+# Prettier target paths (must match CI)
+prettier_targets() {
+  local component="$1"
+  case "$component" in
+    jupyter-mcp)  echo "jupyter-mcp/src/**/*.ts" ;;
+    document-mcp) echo "document-mcp/src/**/*.ts" ;;
+    mcp-shared)   echo "packages/mcp-shared/src/**/*.ts" ;;
+  esac
+}
+
+# Ruff target paths (must match CI)
+ruff_targets() {
+  local component="$1"
+  case "$component" in
+    document-server) echo "document-server/src/ document-server/tests/" ;;
+    jupyter-server)  echo "jupyter-server/extensions/ jupyter-server/tests/" ;;
+    scripts)         echo "scripts/*.py scripts/lib/*.py" ;;
+  esac
+}
+
+# ── Parse arguments ──
+
+TARGETS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    -*)        echo "Error: unknown option $1" >&2; usage; exit 1 ;;
+    *)
+      found=false
+      for c in "${ALL_COMPONENTS[@]}"; do
+        if [[ "$1" == "$c" ]]; then found=true; break; fi
+      done
+      if ! $found; then
+        echo "Error: unknown component '$1' (available: ${ALL_COMPONENTS[*]})" >&2
+        exit 1
+      fi
+      TARGETS+=("$1"); shift ;;
+  esac
+done
+
+if [[ ${#TARGETS[@]} -eq 0 ]]; then
+  TARGETS=("${ALL_COMPONENTS[@]}")
+fi
+
+# ── Classify targets ──
+
+TS_TARGETS=()
+PY_TARGETS=()
+
+for t in "${TARGETS[@]}"; do
+  for c in "${TS_COMPONENTS[@]}"; do
+    if [[ "$t" == "$c" ]]; then TS_TARGETS+=("$t"); fi
+  done
+  for c in "${PY_COMPONENTS[@]}"; do
+    if [[ "$t" == "$c" ]]; then PY_TARGETS+=("$t"); fi
+  done
+done
+
+# ── Run checks ──
+
+echo "=== Lint / Format Check ==="
+FAILED=()
+
+# TypeScript: prettier --check
+if [[ ${#TS_TARGETS[@]} -gt 0 ]]; then
+  echo ""
+  echo "--- Prettier (TypeScript) ---"
+
+  if ! command -v npx >/dev/null 2>&1; then
+    echo "  ERROR: npx not found. Install Node.js." >&2
+    FAILED+=("prettier:not-found")
+  else
+    PRETTIER_GLOBS=()
+    for component in "${TS_TARGETS[@]}"; do
+      PRETTIER_GLOBS+=("$(prettier_targets "$component")")
+    done
+
+    echo "  Checking: ${PRETTIER_GLOBS[*]}"
+    if npx prettier --check "${PRETTIER_GLOBS[@]}" 2>&1; then
+      echo "  Prettier OK"
+    else
+      FAILED+=("prettier")
+      echo "  FAILED: prettier"
+    fi
+  fi
+fi
+
+# Python: ruff format --check + ruff check
+if [[ ${#PY_TARGETS[@]} -gt 0 ]]; then
+  echo ""
+  echo "--- Ruff (Python) ---"
+
+  if ! command -v ruff >/dev/null 2>&1; then
+    echo "  ERROR: ruff not found. Install with: pip install ruff" >&2
+    FAILED+=("ruff:not-found")
+  else
+    RUFF_PATHS=()
+    for component in "${PY_TARGETS[@]}"; do
+      # Word-split intentionally — paths may contain multiple entries
+      # shellcheck disable=SC2206
+      RUFF_PATHS+=($(ruff_targets "$component"))
+    done
+
+    echo "  Checking format: ${RUFF_PATHS[*]}"
+    if ruff format --check "${RUFF_PATHS[@]}" 2>&1; then
+      echo "  Ruff format OK"
+    else
+      FAILED+=("ruff-format")
+      echo "  FAILED: ruff format"
+    fi
+
+    echo "  Checking lint: ${RUFF_PATHS[*]}"
+    if ruff check "${RUFF_PATHS[@]}" 2>&1; then
+      echo "  Ruff lint OK"
+    else
+      FAILED+=("ruff-lint")
+      echo "  FAILED: ruff lint"
+    fi
+  fi
+fi
+
+# ── Result ──
+
+echo ""
+echo "=== Lint Result ==="
+if [[ ${#FAILED[@]} -eq 0 ]]; then
+  echo "All checks passed."
+else
+  echo "FAILED: ${FAILED[*]}"
+  exit 1
+fi

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -25,6 +25,7 @@ OPTIONS:
   --integration   統合テスト（Docker 環境が必要）
   --rebuild       テスト前にコンポーネントを自動リビルド（MCP/Docker を自動判定）
   --health        テスト後に既知障害と照合して分類する
+  --no-lint       lint / format チェックをスキップする
   -h, --help      このヘルプを表示
 
 Examples:
@@ -41,6 +42,7 @@ EOF
 
 TYPECHECK=true
 TEST=true
+LINT=true
 HEALTH=false
 INTEGRATION=false
 REBUILD=false
@@ -52,6 +54,7 @@ while [[ $# -gt 0 ]]; do
     --test)          TYPECHECK=false; shift ;;
     --integration)   INTEGRATION=true; shift ;;
     --rebuild)       REBUILD=true; shift ;;
+    --no-lint)       LINT=false; shift ;;
     --health)        HEALTH=true; shift ;;
     -h|--help)    usage; exit 0 ;;
     -*)           echo "Error: unknown option $1" >&2; usage; exit 1 ;;
@@ -97,8 +100,31 @@ run_rebuild() {
 
 echo "=== Test Runner ==="
 echo "Targets: ${TARGETS[*]}"
-echo "Typecheck: $TYPECHECK | Test: $TEST | Integration: $INTEGRATION"
+echo "Typecheck: $TYPECHECK | Test: $TEST | Lint: $LINT | Integration: $INTEGRATION"
 echo ""
+
+# Lint check (before any build/test)
+if $LINT; then
+  echo "--- Lint / Format Check ---"
+  # Map test.sh component names to lint.sh component names
+  # test.sh targets: jupyter-mcp, document-mcp, document-server, jupyter-server
+  # lint.sh also supports: mcp-shared, scripts
+  LINT_TARGETS=()
+  for _t in "${TARGETS[@]}"; do
+    LINT_TARGETS+=("$_t")
+  done
+  # Always include mcp-shared and scripts when running all components
+  if [[ ${#TARGETS[@]} -eq ${#COMPONENTS[@]} ]]; then
+    LINT_TARGETS+=("mcp-shared" "scripts")
+  fi
+  if scripts/lint.sh "${LINT_TARGETS[@]}"; then
+    echo ""
+  else
+    echo ""
+    echo "ERROR: Lint check failed. Fix lint issues before running tests."
+    exit 1
+  fi
+fi
 
 # Integration mode: check Docker environment
 if $INTEGRATION; then


### PR DESCRIPTION
## Summary
- complete-task コマンドでドキュメント不整合の自動修正を有効化
- ローカル lint/format チェックを追加（`scripts/lint.sh`）
- `test.sh` に lint を統合（デフォルト有効、`--no-lint` でスキップ可能）
- CI の lint 対象パスを `lint.sh` に集約し SSoT 化
- lint 失敗時の対応ルール（`.claude/rules/lint.md`）を定義
- 全カスタムコマンドに `lint.md` 参照を追加

## Test plan
- [x] `scripts/lint.sh` 単独実行で全対象 PASS を確認
- [x] `scripts/lint.sh jupyter-mcp` コンポーネント指定の動作確認
- [x] `lint.sh --help` のヘルプ表示確認
- [x] `bash -n scripts/lint.sh` 構文チェック PASS
- [ ] CI で prettier / ruff チェックが `lint.sh` 経由で PASS すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
