### PR TITLE
feat: セルタイプ変更・コピーツール (19.3)

### DIFF
--- a/docs/plan/01-jupyter.md
+++ b/docs/plan/01-jupyter.md
@@ -227,7 +227,7 @@ SQLクエリ結果を大量行対応でワークスペースにファイル保�
 |---|--------|-----------|-----------|------|
 | 19.1 | セル一括実行 | [x] | notebook_execute_batch で全セル/ここまで/これ以降の一括実行ができる | jupyter-server: POST /cells/execute-batch、jupyter-mcp: notebook_execute_batch |
 | 19.2 | セル結合・分割 | [x] | notebook_merge_cells で隣接セルが結合され、notebook_split_cell でセルが分割される | jupyter-server: PATCH /cells (action: merge/split)、jupyter-mcp: 2ツール |
-| 19.3 | セルタイプ変更・コピー | [→] | notebook_change_cell_type でセルタイプが変更され、notebook_copy_cell でセルが複製される | jupyter-server: PATCH /cells (action: change_type/copy)、jupyter-mcp: 2ツール |
+| 19.3 | セルタイプ変更・コピー | [x] | notebook_change_cell_type でセルタイプが変更され、notebook_copy_cell でセルが複製される | jupyter-server: PATCH /cells (action: change_type/copy)、jupyter-mcp: 2ツール |
 | 19.4 | 出力クリア | [ ] | notebook_clear_outputs で単一セル/全セルの出力がクリアされる | jupyter-server: PATCH /cells (action: clear_output) + POST /cells/clear-all-outputs、jupyter-mcp: 1ツール |
 | 19.5 | カーネル再起動・再起動+全セル実行 | [ ] | kernel_restart でカーネルが再起動され、kernel_restart_and_run_all で再起動後に全セルが実行される | jupyter-server: POST /restart-and-run-all、jupyter-mcp: 2ツール |
 | 19.6 | カーネル中断（AI編集ロック貫通） | [ ] | kernel_interrupt で実行中のコードが中断される。AI編集ロック中でも中断可能で、MCP レスポンスに中断通知が含まれる | jupyter-server: interrupt API のロック貫通対応、jupyter-mcp: kernel_interrupt、jupyterlab-ai-sync: ロック中の中断ボタン有効化 |

--- a/docs/plan/01-jupyter.md
+++ b/docs/plan/01-jupyter.md
@@ -227,7 +227,7 @@ SQLクエリ結果を大量行対応でワークスペースにファイル保�
 |---|--------|-----------|-----------|------|
 | 19.1 | セル一括実行 | [x] | notebook_execute_batch で全セル/ここまで/これ以降の一括実行ができる | jupyter-server: POST /cells/execute-batch、jupyter-mcp: notebook_execute_batch |
 | 19.2 | セル結合・分割 | [x] | notebook_merge_cells で隣接セルが結合され、notebook_split_cell でセルが分割される | jupyter-server: PATCH /cells (action: merge/split)、jupyter-mcp: 2ツール |
-| 19.3 | セルタイプ変更・コピー | [ ] | notebook_change_cell_type でセルタイプが変更され、notebook_copy_cell でセルが複製される | jupyter-server: PATCH /cells (action: change_type/copy)、jupyter-mcp: 2ツール |
+| 19.3 | セルタイプ変更・コピー | [→] | notebook_change_cell_type でセルタイプが変更され、notebook_copy_cell でセルが複製される | jupyter-server: PATCH /cells (action: change_type/copy)、jupyter-mcp: 2ツール |
 | 19.4 | 出力クリア | [ ] | notebook_clear_outputs で単一セル/全セルの出力がクリアされる | jupyter-server: PATCH /cells (action: clear_output) + POST /cells/clear-all-outputs、jupyter-mcp: 1ツール |
 | 19.5 | カーネル再起動・再起動+全セル実行 | [ ] | kernel_restart でカーネルが再起動され、kernel_restart_and_run_all で再起動後に全セルが実行される | jupyter-server: POST /restart-and-run-all、jupyter-mcp: 2ツール |
 | 19.6 | カーネル中断（AI編集ロック貫通） | [ ] | kernel_interrupt で実行中のコードが中断される。AI編集ロック中でも中断可能で、MCP レスポンスに中断通知が含まれる | jupyter-server: interrupt API のロック貫通対応、jupyter-mcp: kernel_interrupt、jupyterlab-ai-sync: ロック中の中断ボタン有効化 |

--- a/docs/tasks/jupyter/19.3-cell-change-type-copy.md
+++ b/docs/tasks/jupyter/19.3-cell-change-type-copy.md
@@ -1,0 +1,155 @@
+# タスク詳細: 19.3 セルタイプ変更・コピー
+
+## 概要
+
+セルのタイプを変更する `notebook_change_cell_type` と、セルを指定位置にコピー（複製）する `notebook_copy_cell` を実装する。jupyter-server の `PATCH /cells` に `change_type`/`copy` アクションを追加し、jupyter-mcp に2つのMCPツールを新規作成する。
+
+## 関連ドキュメント
+
+- 要件定義: `docs/requirements/jupyter-server.md` の「F3.3: セル操作」セクション
+- 要件定義: `docs/requirements/jupyter-mcp.md` の「F3.2: セル操作」セクション、「notebook_change_cell_type」「notebook_copy_cell」ツール定義
+- API仕様: `docs/design/api-contracts.md` の「PATCH /api/custom/contents/{path}/cells (action: change_type/copy)」セクション
+- 受け入れ条件: `docs/requirements/jupyter-mcp.md` の「AC13: セル一括操作」
+
+## 実装計画
+
+### 作成するファイル
+
+| ファイル | 内容 |
+|----------|------|
+| `jupyter-server/tests/test_cell_change_type_copy.py` | jupyter-server ユニットテスト（TDD: Red フェーズで先に作成） |
+| `jupyter-mcp/tests/unit/tools/notebook-change-cell-type.test.ts` | notebook_change_cell_type ユニットテスト |
+| `jupyter-mcp/tests/unit/tools/notebook-copy-cell.test.ts` | notebook_copy_cell ユニットテスト |
+| `jupyter-mcp/src/tools/notebook-change-cell-type.ts` | notebook_change_cell_type ツール実装 |
+| `jupyter-mcp/src/tools/notebook-copy-cell.ts` | notebook_copy_cell ツール実装 |
+
+### 修正するファイル
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `jupyter-server/extensions/custom_api/handlers.py` | `ContentsCellsHandler.patch()` に `change_type`/`copy` アクションを追加 |
+| `jupyter-mcp/src/jupyter-client/types.ts` | `CellAction` 型に `'change_type' \| 'copy'` を追加、`CellOperationRequest` にパラメータ追加 |
+| `jupyter-mcp/src/tools/index.ts` | 2ツールを `toolRegistry` に登録、`NOTEBOOK_EDIT_TOOLS` に追加 |
+| `jupyter-mcp/tests/unit/tools/index.test.ts` | ツール登録数の更新（+2） |
+
+### 実装手順
+
+#### 1. テスト作成（Red フェーズ）
+
+1-1. `jupyter-server/tests/test_cell_change_type_copy.py` を作成
+  - 既存パターン（`test_cell_merge_split.py`）に倣い、モック登録 + `importlib` で `handlers.py` をロード
+  - change_type 正常系: code → markdown 変換（outputs と execution_count がクリアされること）、markdown → code 変換
+  - change_type 異常系: 範囲外インデックス、無効な cell_type 値、同じタイプへの変更（許容するが no-op 確認）
+  - copy 正常系: セルを指定位置にコピー、to_index 省略時はソースの直後に挿入
+  - copy 異常系: 範囲外インデックス、範囲外 to_index
+
+1-2. `jupyter-mcp/tests/unit/tools/notebook-change-cell-type.test.ts` を作成
+  - 既存パターン（`notebook-merge-cells.test.ts`）に倣う
+  - 正常系: 基本的なタイプ変更呼び出し
+  - 異常系: `notebook_path` 未指定、`cell_index` 未指定、`new_type` 未指定、無効な `new_type` 値、パストラバーサル、APIエラー
+
+1-3. `jupyter-mcp/tests/unit/tools/notebook-copy-cell.test.ts` を作成
+  - 正常系: 基本的なコピー呼び出し（target_index 指定）、target_index 省略時
+  - 異常系: `notebook_path` 未指定、`source_index` 未指定、パストラバーサル、APIエラー
+
+#### 2. jupyter-server 実装（Green フェーズ）
+
+2-1. `handlers.py` の `ContentsCellsHandler.patch()` に `change_type` アクションを追加
+  - `index`, `cell_type` をリクエストボディから取得
+  - バリデーション: 両方必須、`index` が範囲内、`cell_type` が `"code"` または `"markdown"` のいずれか
+  - 処理: 対象セルの `cell_type` を変更
+  - code → markdown 変換時: `outputs` を `[]` に、`execution_count` を `null` にクリア
+  - markdown → code 変換時: `outputs` を `[]`、`execution_count` を `null` で初期化
+
+2-2. `handlers.py` に `copy` アクションを追加
+  - `index`, `to_index` をリクエストボディから取得
+  - バリデーション: `index` は必須かつ範囲内、`to_index` は省略可（省略時は `index + 1`）
+  - 処理: 対象セルのディープコピーを作成し、`to_index` の位置に挿入
+  - コピー後のセルは `outputs` を `[]`、`execution_count` を `null` にリセット（コードセルの場合）
+
+#### 3. jupyter-mcp 型定義・クライアント
+
+3-1. `types.ts` の `CellAction` に `'change_type' | 'copy'` を追加
+3-2. `CellOperationRequest` に `cell_type` を optional で追加（`to_index` は既存）
+3-3. `client.ts` の `operateCell()` は既存のまま利用可能（PATCH /cells に action を送るだけ）
+
+#### 4. jupyter-mcp ツール実装
+
+4-1. `notebook-change-cell-type.ts` を作成（`notebook-split-cell.ts` をテンプレートに）
+  - `validateAndNormalizeNotebookPath` でパス検証
+  - `cell_index` の必須チェック・数値チェック（`validateCellIndexParam`）
+  - `new_type` の必須チェック・enum チェック（`"code"` | `"markdown"`）
+  - `jupyterClient.operateCell()` で `{ action: 'change_type', index: cell_index, cell_type: new_type }` を送信
+  - `jupyterClient.postAiEvent()` でリアルタイム同期イベント配信
+
+4-2. `notebook-copy-cell.ts` を作成
+  - `validateAndNormalizeNotebookPath` でパス検証
+  - `source_index` の必須チェック・数値チェック（`validateCellIndexParam`）
+  - `target_index` のオプショナルチェック・数値チェック（指定時のみ）
+  - `jupyterClient.operateCell()` で `{ action: 'copy', index: source_index, to_index: target_index }` を送信
+  - `jupyterClient.postAiEvent()` でリアルタイム同期イベント配信
+
+#### 5. ツール登録
+
+5-1. `index.ts` の `toolRegistry` に2ツールのエントリを追加
+  - `notebook_change_cell_type`: 要件定義の inputSchema に従い `notebook_path`, `cell_index`, `new_type` を定義
+  - `notebook_copy_cell`: 要件定義の inputSchema に従い `notebook_path`, `source_index`, `target_index`（optional）を定義
+5-2. `NOTEBOOK_EDIT_TOOLS` Set に `'notebook_change_cell_type'`, `'notebook_copy_cell'` を追加
+5-3. `index.test.ts` のツール登録数を更新（+2）
+
+### 技術的な考慮事項
+
+- **change_type のメタデータクリア**: code → markdown 変換時は `outputs` と `execution_count` をクリアする（要件定義 F3.3 に明記）。markdown → code 変換時も `outputs: []`, `execution_count: null` で初期化する
+- **copy のディープコピー**: セルオブジェクトを `copy.deepcopy()` で複製し、元セルへの参照を持たないようにする
+- **copy の to_index 省略**: API 仕様では `to_index` が必須だが、MCP ツール定義では `target_index` は optional。MCP ツール側で省略時に `source_index + 1` をデフォルトとして API に渡す
+- **AI 編集ロック**: `NOTEBOOK_EDIT_TOOLS` に追加することで `handleToolCall` ミドルウェアが自動的にロック/アンロックを制御する
+- **リアルタイム同期イベント**: change_type は `cell_type_changed`、copy は `cell_copied` のイベントを配信する。既存の `postAiEvent` パターンに従う
+
+## 完了条件
+
+- [ ] `PATCH /api/custom/contents/{path}/cells` で `action: change_type` が動作する
+- [ ] `PATCH /api/custom/contents/{path}/cells` で `action: copy` が動作する
+- [ ] change_type: code → markdown 変換時に outputs と execution_count がクリアされる
+- [ ] change_type: markdown → code 変換が正常に動作する
+- [ ] copy: セルが指定位置に複製される
+- [ ] copy: target_index 省略時にソースの直後に複製される
+- [ ] notebook_change_cell_type MCPツールが正常に動作する
+- [ ] notebook_copy_cell MCPツールが正常に動作する
+- [ ] AI編集モードの自動ロック/アンロックが動作する（NOTEBOOK_EDIT_TOOLS 登録）
+- [ ] リアルタイム同期イベントが配信される
+- [ ] 全ユニットテストが通過する
+- [ ] 型チェックが通過する
+
+## テスト計画
+
+### jupyter-server テスト（`test_cell_change_type_copy.py`）
+
+| カテゴリ | テスト内容 | 件数 |
+|---------|-----------|------|
+| change_type 正常系 | code→markdown（outputs/execution_countクリア確認）、markdown→code | 2 |
+| change_type 異常系 | 範囲外index、無効なcell_type | 2 |
+| copy 正常系 | 指定位置にコピー、to_index省略時（source直後に挿入） | 2 |
+| copy 異常系 | 範囲外index、範囲外to_index | 2 |
+
+計: 8テスト
+
+### jupyter-mcp テスト（2ファイル合計）
+
+| カテゴリ | テスト内容 | 件数 |
+|---------|-----------|------|
+| change_type 正常系 | 基本タイプ変更、レスポンス形式確認 | 2 |
+| change_type 異常系 | 必須パラメータ欠如×3、無効なnew_type、パストラバーサル、APIエラー | 6 |
+| copy 正常系 | 基本コピー（target_index指定）、target_index省略時 | 2 |
+| copy 異常系 | 必須パラメータ欠如×2、パストラバーサル、APIエラー | 4 |
+
+計: 14テスト
+
+**合計: 22テストケース**
+
+---
+
+## レビューステータス
+
+- [x] 計画レビュー完了
+- [ ] 実装完了
+- [ ] テスト完了

--- a/jupyter-mcp/src/jupyter-client/types.ts
+++ b/jupyter-mcp/src/jupyter-client/types.ts
@@ -180,7 +180,7 @@ export interface UpdateNotebookRequest {
   content: NotebookContent;
 }
 
-export type CellAction = 'add' | 'update' | 'delete' | 'reorder' | 'merge' | 'split';
+export type CellAction = 'add' | 'update' | 'delete' | 'reorder' | 'merge' | 'split' | 'change_type' | 'copy';
 
 export interface CellOperationRequest {
   action: CellAction;
@@ -190,6 +190,7 @@ export interface CellOperationRequest {
   start_index?: number;
   end_index?: number;
   split_line?: number;
+  cell_type?: 'code' | 'markdown';
 }
 
 // =============================================================================
@@ -290,7 +291,9 @@ export interface AiEventBase {
     | 'ai_edit_start'
     | 'ai_edit_end'
     | 'cells_merged'
-    | 'cell_split';
+    | 'cell_split'
+    | 'cell_type_changed'
+    | 'cell_copied';
 }
 
 /**
@@ -427,6 +430,28 @@ export interface CellSplitEvent extends AiEventBase {
 }
 
 /**
+ * セルタイプ変更イベント
+ * AIが notebook_change_cell_type ツールを実行した際に配信される
+ */
+export interface CellTypeChangedEvent extends AiEventBase {
+  type: 'cell_type_changed';
+  notebook_path: string;
+  cell_index: number;
+  new_type: 'code' | 'markdown';
+}
+
+/**
+ * セルコピーイベント
+ * AIが notebook_copy_cell ツールを実行した際に配信される
+ */
+export interface CellCopiedEvent extends AiEventBase {
+  type: 'cell_copied';
+  notebook_path: string;
+  source_index: number;
+  target_index: number;
+}
+
+/**
  * AI同期イベントの型定義
  */
 export type AiEvent =
@@ -440,7 +465,9 @@ export type AiEvent =
   | AiEditStartEvent
   | AiEditEndEvent
   | CellsMergedEvent
-  | CellSplitEvent;
+  | CellSplitEvent
+  | CellTypeChangedEvent
+  | CellCopiedEvent;
 
 export interface BroadcastEventResponse {
   broadcasted: boolean;

--- a/jupyter-mcp/src/tools/index.ts
+++ b/jupyter-mcp/src/tools/index.ts
@@ -44,6 +44,8 @@ import { executeDataPreview } from './data-preview.js';
 import { executeFileRead } from './file-read.js';
 import { executeNotebookMergeCells } from './notebook-merge-cells.js';
 import { executeNotebookSplitCell } from './notebook-split-cell.js';
+import { executeNotebookChangeCellType } from './notebook-change-cell-type.js';
+import { executeNotebookCopyCell } from './notebook-copy-cell.js';
 
 const toolRegistry: ToolEntry<McpToolResult>[] = [
   {
@@ -702,6 +704,60 @@ const toolRegistry: ToolEntry<McpToolResult>[] = [
     },
     execute: executeNotebookSplitCell,
   },
+  {
+    definition: {
+      name: 'notebook_change_cell_type',
+      description:
+        'Changes the type of a cell in a notebook (code ↔ markdown). outputs and execution_count are always cleared/initialized on type change.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          notebook_path: {
+            type: 'string',
+            description: 'Notebook path (e.g., analysis.ipynb)',
+          },
+          cell_index: {
+            type: 'number',
+            description: 'Cell index to change type (0-indexed)',
+          },
+          new_type: {
+            type: 'string',
+            enum: ['code', 'markdown'],
+            description: 'New cell type (code or markdown)',
+          },
+        },
+        required: ['notebook_path', 'cell_index', 'new_type'],
+      },
+    },
+    execute: executeNotebookChangeCellType,
+  },
+  {
+    definition: {
+      name: 'notebook_copy_cell',
+      description:
+        'Copies a cell to a specified position within a notebook. The copied cell has its outputs and execution_count cleared (for code cells). If target_index is omitted, the cell is copied immediately after the source cell.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          notebook_path: {
+            type: 'string',
+            description: 'Notebook path (e.g., analysis.ipynb)',
+          },
+          source_index: {
+            type: 'number',
+            description: 'Cell index to copy (0-indexed)',
+          },
+          target_index: {
+            type: 'number',
+            description:
+              'Position to insert the copied cell (0-indexed). If omitted, the cell is inserted immediately after the source cell',
+          },
+        },
+        required: ['notebook_path', 'source_index'],
+      },
+    },
+    execute: executeNotebookCopyCell,
+  },
 ];
 
 /** ノートブック編集系ツール: 実行前後に ai_edit_start/end イベントを自動配信する */
@@ -715,6 +771,8 @@ const NOTEBOOK_EDIT_TOOLS = new Set([
   'notebook_reorder_cell',
   'notebook_merge_cells',
   'notebook_split_cell',
+  'notebook_change_cell_type',
+  'notebook_copy_cell',
 ]);
 
 /**

--- a/jupyter-mcp/src/tools/notebook-change-cell-type.ts
+++ b/jupyter-mcp/src/tools/notebook-change-cell-type.ts
@@ -1,0 +1,67 @@
+/**
+ * notebook_change_cell_type ツール実装
+ */
+
+import {
+  createSuccessResponse,
+  createErrorResponse,
+  extractErrorCode,
+  extractErrorMessage,
+  type McpResponse,
+} from '../utils/response-formatter.js';
+import { validateAndNormalizeNotebookPath, validateCellIndexParam } from '../utils/validation.js';
+import { jupyterClient } from '../jupyter-client/client.js';
+
+/**
+ * セルのタイプを変更する（code ↔ markdown）
+ */
+export async function executeNotebookChangeCellType(args: Record<string, unknown>): Promise<McpResponse> {
+  const pathResult = validateAndNormalizeNotebookPath(args.notebook_path);
+  if ('error' in pathResult) {
+    return createErrorResponse(pathResult.error, 'VALIDATION_ERROR');
+  }
+  const validatedPath = pathResult.path;
+
+  const cellIndexResult = validateCellIndexParam(args.cell_index);
+  if ('error' in cellIndexResult) {
+    return createErrorResponse(cellIndexResult.error, 'VALIDATION_ERROR');
+  }
+  const cellIndex = cellIndexResult.index;
+
+  if (args.new_type === undefined || args.new_type === null) {
+    return createErrorResponse('new_type は必須パラメータです', 'VALIDATION_ERROR');
+  }
+  if (args.new_type !== 'code' && args.new_type !== 'markdown') {
+    return createErrorResponse(
+      `new_type は "code" または "markdown" のいずれかです。指定値: ${String(args.new_type)}`,
+      'VALIDATION_ERROR',
+    );
+  }
+  const newType = args.new_type as 'code' | 'markdown';
+
+  try {
+    // REST API でセルタイプを変更
+    await jupyterClient.operateCell(validatedPath, {
+      action: 'change_type',
+      index: cellIndex,
+      cell_type: newType,
+    });
+
+    // AI同期イベントを配信（ブラウザにリアルタイム反映）
+    await jupyterClient.postAiEvent({
+      type: 'cell_type_changed',
+      notebook_path: validatedPath,
+      cell_index: cellIndex,
+      new_type: newType,
+    });
+
+    return createSuccessResponse({
+      notebook_path: validatedPath,
+      cell_index: cellIndex,
+      new_type: newType,
+      message: `ノートブック "${validatedPath}" のセル ${cellIndex} のタイプを "${newType}" に変更しました`,
+    });
+  } catch (error) {
+    return createErrorResponse(extractErrorMessage(error), extractErrorCode(error));
+  }
+}

--- a/jupyter-mcp/src/tools/notebook-copy-cell.ts
+++ b/jupyter-mcp/src/tools/notebook-copy-cell.ts
@@ -1,0 +1,68 @@
+/**
+ * notebook_copy_cell ツール実装
+ */
+
+import {
+  createSuccessResponse,
+  createErrorResponse,
+  extractErrorCode,
+  extractErrorMessage,
+  type McpResponse,
+} from '../utils/response-formatter.js';
+import { validateAndNormalizeNotebookPath, validateCellIndexParam } from '../utils/validation.js';
+import { jupyterClient } from '../jupyter-client/client.js';
+
+/**
+ * セルを指定位置にコピー（複製）する
+ */
+export async function executeNotebookCopyCell(args: Record<string, unknown>): Promise<McpResponse> {
+  const pathResult = validateAndNormalizeNotebookPath(args.notebook_path);
+  if ('error' in pathResult) {
+    return createErrorResponse(pathResult.error, 'VALIDATION_ERROR');
+  }
+  const validatedPath = pathResult.path;
+
+  const sourceIndexResult = validateCellIndexParam(args.source_index, 'source_index');
+  if ('error' in sourceIndexResult) {
+    return createErrorResponse(sourceIndexResult.error, 'VALIDATION_ERROR');
+  }
+  const sourceIndex = sourceIndexResult.index;
+
+  // target_index はオプショナル。省略時は source_index + 1
+  let targetIndex: number;
+  if (args.target_index === undefined || args.target_index === null) {
+    targetIndex = sourceIndex + 1;
+  } else {
+    const targetIndexResult = validateCellIndexParam(args.target_index, 'target_index');
+    if ('error' in targetIndexResult) {
+      return createErrorResponse(targetIndexResult.error, 'VALIDATION_ERROR');
+    }
+    targetIndex = targetIndexResult.index;
+  }
+
+  try {
+    // REST API でセルをコピー
+    await jupyterClient.operateCell(validatedPath, {
+      action: 'copy',
+      index: sourceIndex,
+      to_index: targetIndex,
+    });
+
+    // AI同期イベントを配信（ブラウザにリアルタイム反映）
+    await jupyterClient.postAiEvent({
+      type: 'cell_copied',
+      notebook_path: validatedPath,
+      source_index: sourceIndex,
+      target_index: targetIndex,
+    });
+
+    return createSuccessResponse({
+      notebook_path: validatedPath,
+      source_index: sourceIndex,
+      target_index: targetIndex,
+      message: `ノートブック "${validatedPath}" のセル ${sourceIndex} を位置 ${targetIndex} にコピーしました`,
+    });
+  } catch (error) {
+    return createErrorResponse(extractErrorMessage(error), extractErrorCode(error));
+  }
+}

--- a/jupyter-mcp/tests/unit/tools/index.test.ts
+++ b/jupyter-mcp/tests/unit/tools/index.test.ts
@@ -95,6 +95,12 @@ vi.mock('../../../src/tools/notebook-merge-cells.js', () => ({
 vi.mock('../../../src/tools/notebook-split-cell.js', () => ({
   executeNotebookSplitCell: vi.fn(async () => mockResponse('notebook_split_cell')),
 }));
+vi.mock('../../../src/tools/notebook-change-cell-type.js', () => ({
+  executeNotebookChangeCellType: vi.fn(async () => mockResponse('notebook_change_cell_type')),
+}));
+vi.mock('../../../src/tools/notebook-copy-cell.js', () => ({
+  executeNotebookCopyCell: vi.fn(async () => mockResponse('notebook_copy_cell')),
+}));
 
 beforeEach(() => {
   mockEmitAiEditStart.mockClear();
@@ -104,7 +110,7 @@ beforeEach(() => {
 describe('registerTools', () => {
   test('全ツールが登録されている', () => {
     const tools = registerTools();
-    expect(tools).toHaveLength(27);
+    expect(tools).toHaveLength(29);
 
     const expectedToolNames = [
       'workspace_create',
@@ -134,6 +140,8 @@ describe('registerTools', () => {
       'file_read',
       'notebook_merge_cells',
       'notebook_split_cell',
+      'notebook_change_cell_type',
+      'notebook_copy_cell',
     ];
 
     const toolNames = tools.map((t) => t.name);

--- a/jupyter-mcp/tests/unit/tools/notebook-change-cell-type.test.ts
+++ b/jupyter-mcp/tests/unit/tools/notebook-change-cell-type.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { executeNotebookChangeCellType } from '../../../src/tools/notebook-change-cell-type.js';
+
+// jupyterClient をモック
+vi.mock('../../../src/jupyter-client/client.js', () => ({
+  jupyterClient: {
+    operateCell: vi.fn(),
+    postAiEvent: vi.fn(),
+  },
+}));
+
+import { jupyterClient } from '../../../src/jupyter-client/client.js';
+
+describe('executeNotebookChangeCellType', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('正常系', () => {
+    test('セルタイプを変更できる', async () => {
+      vi.mocked(jupyterClient.operateCell).mockResolvedValue(undefined);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookChangeCellType({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 0,
+        new_type: 'markdown',
+      });
+
+      // operateCell が change_type アクションで呼ばれたことを確認
+      expect(jupyterClient.operateCell).toHaveBeenCalledWith('analysis.ipynb', {
+        action: 'change_type',
+        index: 0,
+        cell_type: 'markdown',
+      });
+
+      // postAiEvent が cell_type_changed イベントで呼ばれたことを確認
+      expect(jupyterClient.postAiEvent).toHaveBeenCalledWith({
+        type: 'cell_type_changed',
+        notebook_path: 'analysis.ipynb',
+        cell_index: 0,
+        new_type: 'markdown',
+      });
+
+      expect(result.content[0].text).toContain('"success": true');
+      expect(result.content[0].text).toContain('"notebook_path": "analysis.ipynb"');
+      expect(result.content[0].text).toContain('"cell_index": 0');
+      expect(result.content[0].text).toContain('"new_type": "markdown"');
+    });
+
+    test('code タイプへの変更でレスポンスが正しい', async () => {
+      vi.mocked(jupyterClient.operateCell).mockResolvedValue(undefined);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookChangeCellType({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 2,
+        new_type: 'code',
+      });
+
+      expect(jupyterClient.operateCell).toHaveBeenCalledWith('analysis.ipynb', {
+        action: 'change_type',
+        index: 2,
+        cell_type: 'code',
+      });
+
+      expect(result.content[0].text).toContain('"success": true');
+      expect(result.content[0].text).toContain('"new_type": "code"');
+    });
+  });
+
+  describe('異常系 - バリデーションエラー', () => {
+    test('notebook_path 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookChangeCellType({
+        cell_index: 0,
+        new_type: 'markdown',
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('notebook_path');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('cell_index 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookChangeCellType({
+        notebook_path: 'analysis.ipynb',
+        new_type: 'markdown',
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('cell_index');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('new_type 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookChangeCellType({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 0,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('new_type');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('無効な new_type 値 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookChangeCellType({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 0,
+        new_type: 'raw',
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('パストラバーサル攻撃 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookChangeCellType({
+        notebook_path: '../../../etc/passwd',
+        cell_index: 0,
+        new_type: 'markdown',
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('異常系 - API エラー', () => {
+    test('範囲外の cell_index => INVALID_CELL_INDEX エラー', async () => {
+      const error = new Error('セルインデックスが不正です: 999');
+      (error as Record<string, unknown>).code = 'INVALID_CELL_INDEX';
+      vi.mocked(jupyterClient.operateCell).mockRejectedValue(error);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookChangeCellType({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 999,
+        new_type: 'markdown',
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('INVALID_CELL_INDEX');
+    });
+  });
+});

--- a/jupyter-mcp/tests/unit/tools/notebook-copy-cell.test.ts
+++ b/jupyter-mcp/tests/unit/tools/notebook-copy-cell.test.ts
@@ -1,0 +1,131 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { executeNotebookCopyCell } from '../../../src/tools/notebook-copy-cell.js';
+
+// jupyterClient をモック
+vi.mock('../../../src/jupyter-client/client.js', () => ({
+  jupyterClient: {
+    operateCell: vi.fn(),
+    postAiEvent: vi.fn(),
+  },
+}));
+
+import { jupyterClient } from '../../../src/jupyter-client/client.js';
+
+describe('executeNotebookCopyCell', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('正常系', () => {
+    test('セルを指定位置にコピーできる（target_index 指定）', async () => {
+      vi.mocked(jupyterClient.operateCell).mockResolvedValue(undefined);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookCopyCell({
+        notebook_path: 'analysis.ipynb',
+        source_index: 0,
+        target_index: 2,
+      });
+
+      // operateCell が copy アクションで呼ばれたことを確認
+      expect(jupyterClient.operateCell).toHaveBeenCalledWith('analysis.ipynb', {
+        action: 'copy',
+        index: 0,
+        to_index: 2,
+      });
+
+      // postAiEvent が cell_copied イベントで呼ばれたことを確認
+      expect(jupyterClient.postAiEvent).toHaveBeenCalledWith({
+        type: 'cell_copied',
+        notebook_path: 'analysis.ipynb',
+        source_index: 0,
+        target_index: 2,
+      });
+
+      expect(result.content[0].text).toContain('"success": true');
+      expect(result.content[0].text).toContain('"notebook_path": "analysis.ipynb"');
+      expect(result.content[0].text).toContain('"source_index": 0');
+      expect(result.content[0].text).toContain('"target_index": 2');
+    });
+
+    test('target_index 省略時はソースの直後にコピーされる', async () => {
+      vi.mocked(jupyterClient.operateCell).mockResolvedValue(undefined);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookCopyCell({
+        notebook_path: 'analysis.ipynb',
+        source_index: 1,
+      });
+
+      // target_index 省略時、MCP ツール側で source_index + 1 をデフォルトとして渡す
+      expect(jupyterClient.operateCell).toHaveBeenCalledWith('analysis.ipynb', {
+        action: 'copy',
+        index: 1,
+        to_index: 2,
+      });
+
+      expect(jupyterClient.postAiEvent).toHaveBeenCalledWith({
+        type: 'cell_copied',
+        notebook_path: 'analysis.ipynb',
+        source_index: 1,
+        target_index: 2,
+      });
+
+      expect(result.content[0].text).toContain('"success": true');
+      expect(result.content[0].text).toContain('"source_index": 1');
+      expect(result.content[0].text).toContain('"target_index": 2');
+    });
+  });
+
+  describe('異常系 - バリデーションエラー', () => {
+    test('notebook_path 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookCopyCell({
+        source_index: 0,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('notebook_path');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('source_index 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookCopyCell({
+        notebook_path: 'analysis.ipynb',
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('source_index');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('パストラバーサル攻撃 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookCopyCell({
+        notebook_path: '../../../etc/passwd',
+        source_index: 0,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('異常系 - API エラー', () => {
+    test('範囲外の source_index => INVALID_CELL_INDEX エラー', async () => {
+      const error = new Error('セルインデックスが不正です: 999');
+      (error as Record<string, unknown>).code = 'INVALID_CELL_INDEX';
+      vi.mocked(jupyterClient.operateCell).mockRejectedValue(error);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookCopyCell({
+        notebook_path: 'analysis.ipynb',
+        source_index: 999,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('INVALID_CELL_INDEX');
+    });
+  });
+});

--- a/jupyter-server/extensions/custom_api/handlers.py
+++ b/jupyter-server/extensions/custom_api/handlers.py
@@ -6,6 +6,7 @@ api-contracts.md に定義された仕様に従った API を提供する。
 
 from __future__ import annotations
 
+import copy as _copy
 import logging
 import re
 import time
@@ -846,6 +847,63 @@ class ContentsCellsHandler(BaseCustomHandler):
 
                 cells[split_index] = first_cell
                 cells.insert(split_index + 1, second_cell)
+
+            elif action == "change_type":
+                change_index = body.get("index")
+                new_cell_type = body.get("cell_type")
+
+                if change_index is None or new_cell_type is None:
+                    self.write_error_response("VALIDATION_ERROR", "index and cell_type are required", 400)
+                    return
+                if not isinstance(change_index, int) or not isinstance(new_cell_type, str):
+                    self.write_error_response(
+                        "VALIDATION_ERROR", "index must be integer and cell_type must be string", 400
+                    )
+                    return
+                if new_cell_type not in ("code", "markdown"):
+                    self.write_error_response(
+                        "VALIDATION_ERROR", f"cell_type must be 'code' or 'markdown', got: {new_cell_type}", 400
+                    )
+                    return
+                if change_index < 0 or change_index >= len(cells):
+                    self.write_error_response("INVALID_CELL_INDEX", f"Invalid index: {change_index}", 400)
+                    return
+
+                cells[change_index]["cell_type"] = new_cell_type
+                cells[change_index]["outputs"] = []
+                cells[change_index]["execution_count"] = None
+
+            elif action == "copy":
+                copy_index = body.get("index")
+                to_index = body.get("to_index")
+
+                if copy_index is None:
+                    self.write_error_response("VALIDATION_ERROR", "index is required", 400)
+                    return
+                if not isinstance(copy_index, int):
+                    self.write_error_response("VALIDATION_ERROR", "index must be an integer", 400)
+                    return
+                if copy_index < 0 or copy_index >= len(cells):
+                    self.write_error_response("INVALID_CELL_INDEX", f"Invalid index: {copy_index}", 400)
+                    return
+
+                # to_index 省略時は copy_index + 1
+                if to_index is None:
+                    to_index = copy_index + 1
+                if not isinstance(to_index, int):
+                    self.write_error_response("VALIDATION_ERROR", "to_index must be an integer", 400)
+                    return
+                # to_index は 0 〜 len(cells) の範囲（末尾挿入を含む）
+                if to_index < 0 or to_index > len(cells):
+                    self.write_error_response("INVALID_CELL_INDEX", f"Invalid to_index: {to_index}", 400)
+                    return
+
+                copied_cell = _copy.deepcopy(cells[copy_index])
+                if copied_cell.get("cell_type") == "code":
+                    copied_cell["outputs"] = []
+                    copied_cell["execution_count"] = None
+
+                cells.insert(to_index, copied_cell)
 
             else:
                 self.write_error_response("VALIDATION_ERROR", f"Unknown action: {action}", 400)

--- a/jupyter-server/tests/test_cell_change_type_copy.py
+++ b/jupyter-server/tests/test_cell_change_type_copy.py
@@ -1,0 +1,339 @@
+"""ContentsCellsHandler の change_type/copy アクションのユニットテスト
+
+handlers.py の ContentsCellsHandler.patch() に change_type/copy アクションを追加する。
+ハンドラーの処理ロジックを直接インポートしてモックでテストする。
+
+テスト対象のアクションがまだ存在しないため（TDD Red フェーズ）、
+ハンドラーの存在確認とアクション実行結果のテストを行う。
+"""
+
+import importlib.util
+import sys
+import types as _types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_ext_dir = Path(__file__).resolve().parent.parent / "extensions"
+
+# --- 1. 重い依存のモック ---
+for _mod_name in ("pandas", "sqlalchemy", "sqlalchemy.exc", "tornado", "tornado.web"):
+    if _mod_name not in sys.modules:
+        _m = _types.ModuleType(_mod_name)
+        if _mod_name == "tornado.web":
+            _m.authenticated = lambda f: f
+        sys.modules[_mod_name] = _m
+
+# --- 2. custom_api パッケージ構造の構築 ---
+if "custom_api" not in sys.modules:
+    _pkg = _types.ModuleType("custom_api")
+    _pkg.__path__ = [str(_ext_dir / "custom_api")]
+    _pkg.__package__ = "custom_api"
+    sys.modules["custom_api"] = _pkg
+
+# base モジュールのモック
+if "custom_api.base" not in sys.modules:
+    _base_mock = _types.ModuleType("custom_api.base")
+    _base_mock.__package__ = "custom_api"
+    _base_mock.BaseCustomHandler = type("BaseCustomHandler", (), {})
+    _base_mock.resolve_workspace_dir = lambda *a, **kw: None
+    _base_mock.validate_timeout = lambda *a, **kw: (30, None)
+    _base_mock.validate_workspace_id = lambda *a, **kw: None
+    _base_mock.workspace_contents_path = lambda *a, **kw: ""
+    _base_mock.utc_now_iso = lambda: "2026-01-01T00:00:00Z"
+    _base_mock.WORKSPACE_ROOT_DIR = "/home/jovyan/work/workspaces/sample"
+    _base_mock.WORKSPACE_PATH_PREFIX = "workspaces/sample"
+    _base_mock.JUPYTER_ROOT_DIR = "/home/jovyan/work"
+    _base_mock.validate_kernel_name = lambda *a, **kw: None
+    sys.modules["custom_api.base"] = _base_mock
+
+# ai_events モジュールのモック
+if "custom_api.ai_events" not in sys.modules:
+    _ai_events_mock = _types.ModuleType("custom_api.ai_events")
+    _ai_events_mock.__package__ = "custom_api"
+    _ai_events_mock.AiEventsWebSocketHandler = type("AiEventsWebSocketHandler", (), {})
+    _ai_events_mock.AiEventsPostHandler = type("AiEventsPostHandler", (), {})
+    sys.modules["custom_api.ai_events"] = _ai_events_mock
+
+# code_validator モジュール（実際にロード — 純粋関数のため）
+if "custom_api.code_validator" not in sys.modules:
+    _cv_path = _ext_dir / "custom_api" / "code_validator.py"
+    _cv_spec = importlib.util.spec_from_file_location(
+        "custom_api.code_validator", _cv_path, submodule_search_locations=[]
+    )
+    _cv_mod = importlib.util.module_from_spec(_cv_spec)
+    _cv_mod.__package__ = "custom_api"
+    sys.modules["custom_api.code_validator"] = _cv_mod
+    _cv_spec.loader.exec_module(_cv_mod)
+
+# kernel_executor モジュールのモック
+if "custom_api.kernel_executor" not in sys.modules:
+    _ke_mock = _types.ModuleType("custom_api.kernel_executor")
+    _ke_mock.__package__ = "custom_api"
+    _ke_mock.KernelExecutor = MagicMock
+    sys.modules["custom_api.kernel_executor"] = _ke_mock
+
+# session_handlers モジュールのモック
+if "custom_api.session_handlers" not in sys.modules:
+    _sh_mock = _types.ModuleType("custom_api.session_handlers")
+    _sh_mock.__package__ = "custom_api"
+    _sh_mock.CustomSessionsHandler = type("CustomSessionsHandler", (), {})
+    _sh_mock.get_kernel_workspace = lambda *a: None
+    _sh_mock.unregister_kernel = lambda *a: None
+    sys.modules["custom_api.session_handlers"] = _sh_mock
+
+# sql_handlers モジュールのモック
+if "custom_api.sql_handlers" not in sys.modules:
+    _sql_mock = _types.ModuleType("custom_api.sql_handlers")
+    _sql_mock.__package__ = "custom_api"
+    _sql_mock.SqlExecuteHandler = type("SqlExecuteHandler", (), {})
+    _sql_mock.SqlExportHandler = type("SqlExportHandler", (), {})
+    sys.modules["custom_api.sql_handlers"] = _sql_mock
+
+# workspace_handlers モジュールのモック
+if "custom_api.workspace_handlers" not in sys.modules:
+    _wh_mock = _types.ModuleType("custom_api.workspace_handlers")
+    _wh_mock.__package__ = "custom_api"
+    _wh_mock.WorkspaceHandler = type("WorkspaceHandler", (), {})
+    _wh_mock.WorkspacesHandler = type("WorkspacesHandler", (), {})
+    _wh_mock.WorkspaceSummarizeHandler = type("WorkspaceSummarizeHandler", (), {})
+    sys.modules["custom_api.workspace_handlers"] = _wh_mock
+
+# --- 3. handlers モジュールをロード ---
+_module_path = _ext_dir / "custom_api" / "handlers.py"
+_handlers_spec = importlib.util.spec_from_file_location(
+    "custom_api.handlers",
+    _module_path,
+    submodule_search_locations=[],
+)
+_handlers = importlib.util.module_from_spec(_handlers_spec)
+_handlers.__package__ = "custom_api"
+sys.modules["custom_api.handlers"] = _handlers
+_handlers_spec.loader.exec_module(_handlers)
+
+ContentsCellsHandler = _handlers.ContentsCellsHandler
+
+
+# ============================================================
+# ヘルパー: ContentsCellsHandler のモックインスタンスを作成
+# ============================================================
+
+
+def _make_handler(cells: list[dict], path: str = "workspaces/sample/ws-001/test.ipynb"):
+    """ContentsCellsHandler のモックを作成し、patch() を呼べるようにする"""
+    handler = MagicMock(spec=ContentsCellsHandler)
+
+    model = {
+        "type": "notebook",
+        "content": {"cells": [dict(c) for c in cells]},
+    }
+
+    handler.get_json_body = MagicMock()
+    handler.contents_manager = MagicMock()
+    handler.contents_manager.get = AsyncMock(return_value=model)
+    handler.contents_manager.save = AsyncMock()
+
+    _responses = []
+    handler.write_success = MagicMock(side_effect=lambda d: _responses.append(("success", d)))
+    handler.write_error_response = MagicMock(
+        side_effect=lambda code, msg, status: _responses.append(("error", code, msg, status))
+    )
+    handler._responses = _responses
+    handler._model = model
+
+    return handler, path
+
+
+async def _call_patch(handler, path, body):
+    """handler.patch() をバインドして呼び出す"""
+    handler.get_json_body.return_value = body
+    await ContentsCellsHandler.patch(handler, path)
+
+
+# ============================================================
+# change_type 正常系テスト
+# ============================================================
+
+
+class TestChangeTypeNormal:
+    """change_type アクションの正常系テスト"""
+
+    @pytest.mark.asyncio
+    async def test_change_type_code_to_markdown(self):
+        """code → markdown 変換: outputs と execution_count がクリアされる"""
+        cells = [
+            {
+                "cell_type": "code",
+                "source": "print('hello')",
+                "outputs": [{"output_type": "stream", "text": "hello\n"}],
+                "execution_count": 5,
+            },
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "change_type", "index": 0, "cell_type": "markdown"})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "success"
+
+        handler.contents_manager.save.assert_called_once()
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        changed_cells = saved_model["content"]["cells"]
+        assert len(changed_cells) == 1
+        assert changed_cells[0]["cell_type"] == "markdown"
+        assert changed_cells[0]["source"] == "print('hello')"
+        assert changed_cells[0]["outputs"] == []
+        assert changed_cells[0]["execution_count"] is None
+
+    @pytest.mark.asyncio
+    async def test_change_type_markdown_to_code(self):
+        """markdown → code 変換: outputs と execution_count が初期化される"""
+        cells = [
+            {
+                "cell_type": "markdown",
+                "source": "# Title",
+            },
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "change_type", "index": 0, "cell_type": "code"})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "success"
+
+        handler.contents_manager.save.assert_called_once()
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        changed_cells = saved_model["content"]["cells"]
+        assert len(changed_cells) == 1
+        assert changed_cells[0]["cell_type"] == "code"
+        assert changed_cells[0]["source"] == "# Title"
+        assert changed_cells[0]["outputs"] == []
+        assert changed_cells[0]["execution_count"] is None
+
+
+# ============================================================
+# change_type 異常系テスト
+# ============================================================
+
+
+class TestChangeTypeError:
+    """change_type アクションの異常系テスト"""
+
+    @pytest.mark.asyncio
+    async def test_change_type_out_of_range_index(self):
+        """範囲外のインデックスでエラー"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "change_type", "index": 5, "cell_type": "markdown"})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "error"
+
+    @pytest.mark.asyncio
+    async def test_change_type_invalid_cell_type(self):
+        """無効な cell_type 値でエラー"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "change_type", "index": 0, "cell_type": "raw"})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "error"
+
+
+# ============================================================
+# copy 正常系テスト
+# ============================================================
+
+
+class TestCopyNormal:
+    """copy アクションの正常系テスト"""
+
+    @pytest.mark.asyncio
+    async def test_copy_cell_to_specified_position(self):
+        """セルを指定位置にコピー"""
+        cells = [
+            {
+                "cell_type": "code",
+                "source": "a = 1",
+                "outputs": [{"output_type": "stream", "text": "1\n"}],
+                "execution_count": 3,
+            },
+            {"cell_type": "code", "source": "b = 2", "outputs": [], "execution_count": None},
+            {"cell_type": "markdown", "source": "# End"},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "copy", "index": 0, "to_index": 2})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "success"
+
+        handler.contents_manager.save.assert_called_once()
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        result_cells = saved_model["content"]["cells"]
+        assert len(result_cells) == 4
+        # コピーされたセルは to_index=2 の位置に挿入される
+        assert result_cells[2]["cell_type"] == "code"
+        assert result_cells[2]["source"] == "a = 1"
+        # コードセルのコピーは outputs と execution_count がリセットされる
+        assert result_cells[2]["outputs"] == []
+        assert result_cells[2]["execution_count"] is None
+        # 元のセルは変更されない
+        assert result_cells[0]["source"] == "a = 1"
+        assert result_cells[0]["execution_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_copy_cell_without_to_index(self):
+        """to_index 省略時はソースの直後に挿入"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1", "outputs": [], "execution_count": None},
+            {"cell_type": "markdown", "source": "# End"},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "copy", "index": 0})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "success"
+
+        handler.contents_manager.save.assert_called_once()
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        result_cells = saved_model["content"]["cells"]
+        assert len(result_cells) == 3
+        # index=0 の直後 (位置1) にコピーされる
+        assert result_cells[1]["cell_type"] == "code"
+        assert result_cells[1]["source"] == "a = 1"
+
+
+# ============================================================
+# copy 異常系テスト
+# ============================================================
+
+
+class TestCopyError:
+    """copy アクションの異常系テスト"""
+
+    @pytest.mark.asyncio
+    async def test_copy_out_of_range_index(self):
+        """範囲外の index でエラー"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "copy", "index": 5})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "error"
+
+    @pytest.mark.asyncio
+    async def test_copy_out_of_range_to_index(self):
+        """範囲外の to_index でエラー"""
+        cells = [
+            {"cell_type": "code", "source": "a = 1", "outputs": [], "execution_count": None},
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "copy", "index": 0, "to_index": 100})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "error"


### PR DESCRIPTION
## Summary
- `notebook_change_cell_type` MCPツール: セルタイプ変更（code ↔ markdown）、変換時に outputs/execution_count をクリア/初期化
- `notebook_copy_cell` MCPツール: セルを指定位置にディープコピー、target_index 省略時はソース直後に挿入
- jupyter-server `PATCH /cells` に `change_type`/`copy` アクションを追加
- AI編集モード自動ロック/アンロック対応（NOTEBOOK_EDIT_TOOLS 登録）
- リアルタイム同期イベント配信（cell_type_changed / cell_copied）

## Test plan
- [x] jupyter-server ユニットテスト 8件（change_type 正常系2 + 異常系2、copy 正常系2 + 異常系2）
- [x] jupyter-mcp ユニットテスト 14件（change_type 8件、copy 6件）
- [x] 既存テスト全パス（jupyter-server: 245, jupyter-mcp: 401）
- [x] 型チェック・lint パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
