### PR TITLE
feat: 出力クリアツール (19.4)

### DIFF
--- a/docs/plan/01-jupyter.md
+++ b/docs/plan/01-jupyter.md
@@ -228,7 +228,7 @@ SQLクエリ結果を大量行対応でワークスペースにファイル保�
 | 19.1 | セル一括実行 | [x] | notebook_execute_batch で全セル/ここまで/これ以降の一括実行ができる | jupyter-server: POST /cells/execute-batch、jupyter-mcp: notebook_execute_batch |
 | 19.2 | セル結合・分割 | [x] | notebook_merge_cells で隣接セルが結合され、notebook_split_cell でセルが分割される | jupyter-server: PATCH /cells (action: merge/split)、jupyter-mcp: 2ツール |
 | 19.3 | セルタイプ変更・コピー | [x] | notebook_change_cell_type でセルタイプが変更され、notebook_copy_cell でセルが複製される | jupyter-server: PATCH /cells (action: change_type/copy)、jupyter-mcp: 2ツール |
-| 19.4 | 出力クリア | [→] | notebook_clear_outputs で単一セル/全セルの出力がクリアされる | jupyter-server: PATCH /cells (action: clear_output) + POST /cells/clear-all-outputs、jupyter-mcp: 1ツール |
+| 19.4 | 出力クリア | [x] | notebook_clear_outputs で単一セル/全セルの出力がクリアされる | jupyter-server: PATCH /cells (action: clear_output) + POST /cells/clear-all-outputs、jupyter-mcp: 1ツール |
 | 19.5 | カーネル再起動・再起動+全セル実行 | [ ] | kernel_restart でカーネルが再起動され、kernel_restart_and_run_all で再起動後に全セルが実行される | jupyter-server: POST /restart-and-run-all、jupyter-mcp: 2ツール |
 | 19.6 | カーネル中断（AI編集ロック貫通） | [ ] | kernel_interrupt で実行中のコードが中断される。AI編集ロック中でも中断可能で、MCP レスポンスに中断通知が含まれる | jupyter-server: interrupt API のロック貫通対応、jupyter-mcp: kernel_interrupt、jupyterlab-ai-sync: ロック中の中断ボタン有効化 |
 | 19.7 | ノートブック操作拡張の結合テスト | [ ] | 一括実行→結合→分割→タイプ変更→コピー→出力クリア→カーネル再起動の一連フローが動作する | 統合テスト |

--- a/docs/plan/01-jupyter.md
+++ b/docs/plan/01-jupyter.md
@@ -228,7 +228,7 @@ SQLクエリ結果を大量行対応でワークスペースにファイル保�
 | 19.1 | セル一括実行 | [x] | notebook_execute_batch で全セル/ここまで/これ以降の一括実行ができる | jupyter-server: POST /cells/execute-batch、jupyter-mcp: notebook_execute_batch |
 | 19.2 | セル結合・分割 | [x] | notebook_merge_cells で隣接セルが結合され、notebook_split_cell でセルが分割される | jupyter-server: PATCH /cells (action: merge/split)、jupyter-mcp: 2ツール |
 | 19.3 | セルタイプ変更・コピー | [x] | notebook_change_cell_type でセルタイプが変更され、notebook_copy_cell でセルが複製される | jupyter-server: PATCH /cells (action: change_type/copy)、jupyter-mcp: 2ツール |
-| 19.4 | 出力クリア | [ ] | notebook_clear_outputs で単一セル/全セルの出力がクリアされる | jupyter-server: PATCH /cells (action: clear_output) + POST /cells/clear-all-outputs、jupyter-mcp: 1ツール |
+| 19.4 | 出力クリア | [→] | notebook_clear_outputs で単一セル/全セルの出力がクリアされる | jupyter-server: PATCH /cells (action: clear_output) + POST /cells/clear-all-outputs、jupyter-mcp: 1ツール |
 | 19.5 | カーネル再起動・再起動+全セル実行 | [ ] | kernel_restart でカーネルが再起動され、kernel_restart_and_run_all で再起動後に全セルが実行される | jupyter-server: POST /restart-and-run-all、jupyter-mcp: 2ツール |
 | 19.6 | カーネル中断（AI編集ロック貫通） | [ ] | kernel_interrupt で実行中のコードが中断される。AI編集ロック中でも中断可能で、MCP レスポンスに中断通知が含まれる | jupyter-server: interrupt API のロック貫通対応、jupyter-mcp: kernel_interrupt、jupyterlab-ai-sync: ロック中の中断ボタン有効化 |
 | 19.7 | ノートブック操作拡張の結合テスト | [ ] | 一括実行→結合→分割→タイプ変更→コピー→出力クリア→カーネル再起動の一連フローが動作する | 統合テスト |

--- a/docs/tasks/jupyter/19.4-clear-outputs.md
+++ b/docs/tasks/jupyter/19.4-clear-outputs.md
@@ -1,0 +1,155 @@
+# タスク詳細: 19.4 出力クリア
+
+## 概要
+
+セルの出力をクリアする `notebook_clear_outputs` MCPツールを実装する。単一セル（`cell_index` 指定）と全セル（`cell_index` 省略）の両方に対応する。jupyter-server に `PATCH /cells` の `clear_output` アクションと `POST /cells/clear-all-outputs` エンドポイントを追加し、jupyter-mcp に1つのMCPツールを新規作成する。
+
+## 関連ドキュメント
+
+- 要件定義: `docs/requirements/jupyter-server.md` の「F3.3: セル操作」セクション（セルの出力をクリアできる（単一セル / 全セル））
+- 要件定義: `docs/requirements/jupyter-mcp.md` の「F3.2: セル操作」セクション、「notebook_clear_outputs」ツール定義
+- API仕様: `docs/design/api-contracts.md` の「PATCH /api/custom/contents/{path}/cells (action: clear_output)」および「POST /api/custom/contents/{path}/cells/clear-all-outputs」セクション
+- 受け入れ条件: `docs/requirements/jupyter-server.md` の「AC11: セル一括操作」、`docs/requirements/jupyter-mcp.md` の「AC13: セル一括操作」
+
+## 実装計画
+
+### 作成するファイル
+
+| ファイル | 内容 |
+|----------|------|
+| `jupyter-server/tests/test_cell_clear_outputs.py` | jupyter-server ユニットテスト（TDD: Red フェーズで先に作成） |
+| `jupyter-mcp/tests/unit/tools/notebook-clear-outputs.test.ts` | notebook_clear_outputs ユニットテスト |
+| `jupyter-mcp/src/tools/notebook-clear-outputs.ts` | notebook_clear_outputs ツール実装 |
+
+### 修正するファイル
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `jupyter-server/extensions/custom_api/handlers.py` | `ContentsCellsHandler.patch()` に `clear_output` アクションを追加、`ContentsClearAllOutputsHandler` クラスを新規作成 |
+| `jupyter-server/extensions/custom_api/handlers.py` (`get_handlers`) | `clear-all-outputs` の URL パターンを登録 |
+| `jupyter-mcp/src/jupyter-client/types.ts` | `CellAction` 型に `'clear_output'` を追加 |
+| `jupyter-mcp/src/jupyter-client/client.ts` | `clearAllOutputs()` メソッドを追加（`POST /cells/clear-all-outputs` 呼び出し用） |
+| `jupyter-mcp/src/tools/index.ts` | 1ツールを `toolRegistry` に登録、`NOTEBOOK_EDIT_TOOLS` に追加 |
+| `jupyter-mcp/tests/unit/tools/index.test.ts` | ツール登録数の更新（+1） |
+
+### 実装手順
+
+#### 1. テスト作成（Red フェーズ）
+
+1-1. `jupyter-server/tests/test_cell_clear_outputs.py` を作成
+  - 既存パターン（`test_cell_change_type_copy.py`）に倣い、モック登録 + `importlib` で `handlers.py` をロード
+  - clear_output 正常系: コードセルの出力クリア（outputs が `[]` に、execution_count が `null` になること）
+  - clear_output 正常系: マークダウンセルに対しても正常に動作する（no-op に近いが、エラーにならないこと）
+  - clear_output 異常系: 範囲外インデックス
+  - clear-all-outputs 正常系: 全コードセルの outputs が `[]`、execution_count が `null` になること
+  - clear-all-outputs 正常系: マークダウンセルはスキップされること（outputs フィールドを持たないため）
+  - clear-all-outputs 正常系: セルがない場合も正常終了すること（cleared_cells: 0）
+
+1-2. `jupyter-mcp/tests/unit/tools/notebook-clear-outputs.test.ts` を作成
+  - 既存パターン（`notebook-copy-cell.test.ts`）に倣う
+  - 正常系: 単一セル出力クリア（cell_index 指定）、`operateCell` が `clear_output` アクションで呼ばれること
+  - 正常系: 全セル出力クリア（cell_index 省略）、`clearAllOutputs` が呼ばれること
+  - 異常系: `notebook_path` 未指定、パストラバーサル、APIエラー
+  - 異常系: `cell_index` に非数値が指定された場合
+
+#### 2. jupyter-server 実装（Green フェーズ）
+
+2-1. `handlers.py` の `ContentsCellsHandler.patch()` に `clear_output` アクションを追加
+  - `index` をリクエストボディから取得（必須）
+  - バリデーション: `index` が整数かつ範囲内
+  - 処理: 対象セルの `outputs` を `[]` に、`execution_count` を `None` にリセット
+
+2-2. `ContentsClearAllOutputsHandler` クラスを新規作成
+  - `POST /api/custom/contents/{path}/cells/clear-all-outputs` に対応
+  - 既存パターン（`ContentsCellExecuteBatchHandler`）に倣う
+  - 処理: 全セルを走査し、コードセル（`cell_type == "code"`）の `outputs` を `[]`、`execution_count` を `None` にリセット
+  - レスポンス: `{ "data": { "cleared_cells": N } }`（N はクリアされたセル数）
+  - ノートブックの保存は `_save_notebook()` を使用
+
+2-3. `get_handlers()` に URL パターンを登録
+  - `clear-all-outputs` は `cells` より前に登録する（URL マッチング順序の問題。`execute-batch` と同様に `cells` の前に配置）
+
+#### 3. jupyter-mcp 型定義・クライアント
+
+3-1. `types.ts` の `CellAction` に `'clear_output'` を追加
+3-2. `client.ts` に `clearAllOutputs(path: string)` メソッドを追加
+  - `POST /api/custom/contents/{path}/cells/clear-all-outputs` を呼び出し
+  - レスポンスから `cleared_cells` を返す
+
+#### 4. jupyter-mcp ツール実装
+
+4-1. `notebook-clear-outputs.ts` を作成（`notebook-copy-cell.ts` をテンプレートに）
+  - `validateAndNormalizeNotebookPath` でパス検証
+  - `cell_index` の有無で分岐:
+    - **指定あり**: `validateCellIndexParam` で検証後、`jupyterClient.operateCell()` で `{ action: 'clear_output', index: cell_index }` を送信
+    - **指定なし（省略）**: `jupyterClient.clearAllOutputs()` で全セルクリアを実行
+  - `jupyterClient.postAiEvent()` でリアルタイム同期イベント配信（`output_cleared` イベント）
+
+#### 5. ツール登録
+
+5-1. `index.ts` の `toolRegistry` にツールエントリを追加
+  - `notebook_clear_outputs`: 要件定義の inputSchema に従い `notebook_path`（必須）, `cell_index`（optional）を定義
+5-2. `NOTEBOOK_EDIT_TOOLS` Set に `'notebook_clear_outputs'` を追加
+5-3. `index.test.ts` のツール登録数を更新（+1）
+
+### 技術的な考慮事項
+
+- **単一セル vs 全セルの API 分岐**: MCP ツールは1つだが、`cell_index` の有無で呼び出す REST API が異なる。`cell_index` 指定時は `PATCH /cells` (action: clear_output)、省略時は `POST /cells/clear-all-outputs` を使う
+- **マークダウンセルの扱い**: マークダウンセルには `outputs` フィールドがないため、全セルクリア時はコードセルのみを対象にする。単一セル指定時にマークダウンセルを指定しても、outputs が存在しなければ何もしないが、エラーにはしない
+- **URL マッチング順序**: `clear-all-outputs` のURLパターンは `(.*)/cells` のパターンより先に登録する必要がある。`execute-batch` と同じ位置に配置する
+- **AI 編集ロック**: `NOTEBOOK_EDIT_TOOLS` に追加することで `handleToolCall` ミドルウェアが自動的にロック/アンロックを制御する
+- **operateCell の再利用**: 単一セルクリアは既存の `operateCell()` メソッドで対応可能。`CellAction` に `'clear_output'` を追加し、`CellOperationRequest` に追加フィールドは不要（`action` と `index` のみ使用）
+
+## 完了条件
+
+- [ ] `PATCH /api/custom/contents/{path}/cells` で `action: clear_output` が動作する
+- [ ] `POST /api/custom/contents/{path}/cells/clear-all-outputs` が動作する
+- [ ] 単一セルクリア: outputs が空になり execution_count がリセットされる
+- [ ] 全セルクリア: 全コードセルの outputs が空になり execution_count がリセットされる
+- [ ] 全セルクリア: レスポンスに cleared_cells が含まれる
+- [ ] notebook_clear_outputs MCPツール（cell_index 指定）が正常に動作する
+- [ ] notebook_clear_outputs MCPツール（cell_index 省略）が正常に動作する
+- [ ] AI編集モードの自動ロック/アンロックが動作する（NOTEBOOK_EDIT_TOOLS 登録）
+- [ ] リアルタイム同期イベントが配信される
+- [ ] 全ユニットテストが通過する
+- [ ] 型チェックが通過する
+
+## テスト計画
+
+### jupyter-server テスト（`test_cell_clear_outputs.py`）
+
+| カテゴリ | テスト内容 | 件数 |
+|---------|-----------|------|
+| clear_output 正常系 | コードセルの出力クリア（outputs/execution_count リセット確認） | 1 |
+| clear_output 正常系 | マークダウンセルに対する出力クリア（エラーにならないこと） | 1 |
+| clear_output 異常系 | 範囲外インデックス | 1 |
+| clear-all-outputs 正常系 | 全コードセルの出力クリア + cleared_cells レスポンス確認 | 1 |
+| clear-all-outputs 正常系 | マークダウンセルがスキップされること | 1 |
+| clear-all-outputs 正常系 | セルが0件の場合（cleared_cells: 0） | 1 |
+
+計: 6テスト
+
+### jupyter-mcp テスト（`notebook-clear-outputs.test.ts`）
+
+| カテゴリ | テスト内容 | 件数 |
+|---------|-----------|------|
+| 正常系 | 単一セル出力クリア（cell_index 指定）、operateCell 呼び出し確認 | 1 |
+| 正常系 | 全セル出力クリア（cell_index 省略）、clearAllOutputs 呼び出し確認 | 1 |
+| 正常系 | レスポンス形式確認（success フラグ、メッセージ） | 1 |
+| 異常系 | notebook_path 未指定 | 1 |
+| 異常系 | パストラバーサル | 1 |
+| 異常系 | cell_index に非数値指定 | 1 |
+| 異常系 | API エラー（単一セル） | 1 |
+| 異常系 | API エラー（全セル） | 1 |
+
+計: 8テスト
+
+**合計: 14テストケース**
+
+---
+
+## レビューステータス
+
+- [x] 計画レビュー完了
+- [ ] 実装完了
+- [ ] テスト完了

--- a/jupyter-mcp/src/jupyter-client/client.ts
+++ b/jupyter-mcp/src/jupyter-client/client.ts
@@ -41,6 +41,7 @@ import {
   CellExecuteResponse,
   CellExecuteBatchRequest,
   CellExecuteBatchResponse,
+  ClearAllOutputsResponse,
   DataPreviewResponse,
   DataPreviewOptions,
   TextFileResponse,
@@ -454,6 +455,20 @@ export class JupyterClient {
       request,
       { path, index: cellIndex },
       requestTimeoutMs,
+    );
+    return response.data;
+  }
+
+  // ===========================================================================
+  // 出力クリア
+  // ===========================================================================
+
+  async clearAllOutputs(path: string): Promise<ClearAllOutputsResponse> {
+    const response = await this.request<ApiResponse<ClearAllOutputsResponse>>(
+      'POST',
+      `/api/custom/contents/${encodeURIComponent(path)}/cells/clear-all-outputs`,
+      undefined,
+      { path },
     );
     return response.data;
   }

--- a/jupyter-mcp/src/jupyter-client/types.ts
+++ b/jupyter-mcp/src/jupyter-client/types.ts
@@ -180,7 +180,16 @@ export interface UpdateNotebookRequest {
   content: NotebookContent;
 }
 
-export type CellAction = 'add' | 'update' | 'delete' | 'reorder' | 'merge' | 'split' | 'change_type' | 'copy';
+export type CellAction =
+  | 'add'
+  | 'update'
+  | 'delete'
+  | 'reorder'
+  | 'merge'
+  | 'split'
+  | 'change_type'
+  | 'copy'
+  | 'clear_output';
 
 export interface CellOperationRequest {
   action: CellAction;
@@ -293,7 +302,9 @@ export interface AiEventBase {
     | 'cells_merged'
     | 'cell_split'
     | 'cell_type_changed'
-    | 'cell_copied';
+    | 'cell_copied'
+    | 'output_cleared'
+    | 'all_outputs_cleared';
 }
 
 /**
@@ -452,6 +463,25 @@ export interface CellCopiedEvent extends AiEventBase {
 }
 
 /**
+ * 単一セル出力クリアイベント
+ * AIが notebook_clear_outputs ツールを cell_index 指定で実行した際に配信される
+ */
+export interface OutputClearedEvent extends AiEventBase {
+  type: 'output_cleared';
+  notebook_path: string;
+  cell_index: number;
+}
+
+/**
+ * 全セル出力クリアイベント
+ * AIが notebook_clear_outputs ツールを cell_index 省略で実行した際に配信される
+ */
+export interface AllOutputsClearedEvent extends AiEventBase {
+  type: 'all_outputs_cleared';
+  notebook_path: string;
+}
+
+/**
  * AI同期イベントの型定義
  */
 export type AiEvent =
@@ -467,7 +497,9 @@ export type AiEvent =
   | CellsMergedEvent
   | CellSplitEvent
   | CellTypeChangedEvent
-  | CellCopiedEvent;
+  | CellCopiedEvent
+  | OutputClearedEvent
+  | AllOutputsClearedEvent;
 
 export interface BroadcastEventResponse {
   broadcasted: boolean;
@@ -594,6 +626,14 @@ export interface CellExecuteBatchResponse {
   executed_cells: number;
   success_count: number;
   failed_cell: number | null;
+}
+
+// =============================================================================
+// 出力クリア関連
+// =============================================================================
+
+export interface ClearAllOutputsResponse {
+  cleared_cells: number;
 }
 
 // =============================================================================

--- a/jupyter-mcp/src/tools/index.ts
+++ b/jupyter-mcp/src/tools/index.ts
@@ -46,6 +46,7 @@ import { executeNotebookMergeCells } from './notebook-merge-cells.js';
 import { executeNotebookSplitCell } from './notebook-split-cell.js';
 import { executeNotebookChangeCellType } from './notebook-change-cell-type.js';
 import { executeNotebookCopyCell } from './notebook-copy-cell.js';
+import { executeNotebookClearOutputs } from './notebook-clear-outputs.js';
 
 const toolRegistry: ToolEntry<McpToolResult>[] = [
   {
@@ -758,6 +759,28 @@ const toolRegistry: ToolEntry<McpToolResult>[] = [
     },
     execute: executeNotebookCopyCell,
   },
+  {
+    definition: {
+      name: 'notebook_clear_outputs',
+      description:
+        'Clears the outputs and execution_count of cells in a notebook. When cell_index is specified, only that cell is cleared. When omitted, all code cells in the notebook are cleared.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          notebook_path: {
+            type: 'string',
+            description: 'Notebook path (e.g., analysis.ipynb)',
+          },
+          cell_index: {
+            type: 'integer',
+            description: 'Cell index to clear (0-indexed). If omitted, all code cells are cleared',
+          },
+        },
+        required: ['notebook_path'],
+      },
+    },
+    execute: executeNotebookClearOutputs,
+  },
 ];
 
 /** ノートブック編集系ツール: 実行前後に ai_edit_start/end イベントを自動配信する */
@@ -773,6 +796,7 @@ const NOTEBOOK_EDIT_TOOLS = new Set([
   'notebook_split_cell',
   'notebook_change_cell_type',
   'notebook_copy_cell',
+  'notebook_clear_outputs',
 ]);
 
 /**

--- a/jupyter-mcp/src/tools/notebook-clear-outputs.ts
+++ b/jupyter-mcp/src/tools/notebook-clear-outputs.ts
@@ -1,0 +1,68 @@
+/**
+ * notebook_clear_outputs ツール実装
+ */
+
+import {
+  createSuccessResponse,
+  createErrorResponse,
+  extractErrorCode,
+  extractErrorMessage,
+  type McpResponse,
+} from '../utils/response-formatter.js';
+import { validateAndNormalizeNotebookPath, validateCellIndexParam } from '../utils/validation.js';
+import { jupyterClient } from '../jupyter-client/client.js';
+
+/**
+ * セルの出力をクリアする（単一セルまたは全セル）
+ */
+export async function executeNotebookClearOutputs(args: Record<string, unknown>): Promise<McpResponse> {
+  const pathResult = validateAndNormalizeNotebookPath(args.notebook_path);
+  if ('error' in pathResult) {
+    return createErrorResponse(pathResult.error, 'VALIDATION_ERROR');
+  }
+  const validatedPath = pathResult.path;
+
+  try {
+    if (args.cell_index === undefined || args.cell_index === null) {
+      // 全セルクリア
+      const result = await jupyterClient.clearAllOutputs(validatedPath);
+
+      await jupyterClient.postAiEvent({
+        type: 'all_outputs_cleared',
+        notebook_path: validatedPath,
+      });
+
+      return createSuccessResponse({
+        notebook_path: validatedPath,
+        cleared_cells: result.cleared_cells,
+        message: `ノートブック "${validatedPath}" の全セル出力をクリアしました（${result.cleared_cells} セル）`,
+      });
+    } else {
+      // 単一セルクリア
+      const cellIndexResult = validateCellIndexParam(args.cell_index, 'cell_index');
+      if ('error' in cellIndexResult) {
+        return createErrorResponse(cellIndexResult.error, 'VALIDATION_ERROR');
+      }
+      const cellIndex = cellIndexResult.index;
+
+      await jupyterClient.operateCell(validatedPath, {
+        action: 'clear_output',
+        index: cellIndex,
+      });
+
+      await jupyterClient.postAiEvent({
+        type: 'output_cleared',
+        notebook_path: validatedPath,
+        cell_index: cellIndex,
+      });
+
+      return createSuccessResponse({
+        notebook_path: validatedPath,
+        cell_index: cellIndex,
+        message: `ノートブック "${validatedPath}" のセル ${cellIndex} の出力をクリアしました`,
+      });
+    }
+  } catch (error) {
+    return createErrorResponse(extractErrorMessage(error), extractErrorCode(error));
+  }
+}

--- a/jupyter-mcp/tests/unit/tools/index.test.ts
+++ b/jupyter-mcp/tests/unit/tools/index.test.ts
@@ -101,6 +101,9 @@ vi.mock('../../../src/tools/notebook-change-cell-type.js', () => ({
 vi.mock('../../../src/tools/notebook-copy-cell.js', () => ({
   executeNotebookCopyCell: vi.fn(async () => mockResponse('notebook_copy_cell')),
 }));
+vi.mock('../../../src/tools/notebook-clear-outputs.js', () => ({
+  executeNotebookClearOutputs: vi.fn(async () => mockResponse('notebook_clear_outputs')),
+}));
 
 beforeEach(() => {
   mockEmitAiEditStart.mockClear();
@@ -110,7 +113,7 @@ beforeEach(() => {
 describe('registerTools', () => {
   test('全ツールが登録されている', () => {
     const tools = registerTools();
-    expect(tools).toHaveLength(29);
+    expect(tools).toHaveLength(30);
 
     const expectedToolNames = [
       'workspace_create',
@@ -142,6 +145,7 @@ describe('registerTools', () => {
       'notebook_split_cell',
       'notebook_change_cell_type',
       'notebook_copy_cell',
+      'notebook_clear_outputs',
     ];
 
     const toolNames = tools.map((t) => t.name);

--- a/jupyter-mcp/tests/unit/tools/notebook-clear-outputs.test.ts
+++ b/jupyter-mcp/tests/unit/tools/notebook-clear-outputs.test.ts
@@ -1,0 +1,155 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { executeNotebookClearOutputs } from '../../../src/tools/notebook-clear-outputs.js';
+
+// jupyterClient をモック
+vi.mock('../../../src/jupyter-client/client.js', () => ({
+  jupyterClient: {
+    operateCell: vi.fn(),
+    clearAllOutputs: vi.fn(),
+    postAiEvent: vi.fn(),
+  },
+}));
+
+import { jupyterClient } from '../../../src/jupyter-client/client.js';
+
+describe('executeNotebookClearOutputs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('正常系', () => {
+    test('単一セルの出力クリア（cell_index 指定）', async () => {
+      vi.mocked(jupyterClient.operateCell).mockResolvedValue(undefined);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookClearOutputs({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 2,
+      });
+
+      // operateCell が clear_output アクションで呼ばれたことを確認
+      expect(jupyterClient.operateCell).toHaveBeenCalledWith('analysis.ipynb', {
+        action: 'clear_output',
+        index: 2,
+      });
+
+      // postAiEvent が output_cleared イベントで呼ばれたことを確認
+      expect(jupyterClient.postAiEvent).toHaveBeenCalledWith({
+        type: 'output_cleared',
+        notebook_path: 'analysis.ipynb',
+        cell_index: 2,
+      });
+
+      expect(result.content[0].text).toContain('"success": true');
+      expect(result.content[0].text).toContain('"notebook_path": "analysis.ipynb"');
+      expect(result.content[0].text).toContain('"cell_index": 2');
+    });
+
+    test('全セルの出力クリア（cell_index 省略）', async () => {
+      vi.mocked(jupyterClient.clearAllOutputs).mockResolvedValue({ cleared_cells: 3 });
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookClearOutputs({
+        notebook_path: 'analysis.ipynb',
+      });
+
+      // clearAllOutputs が呼ばれたことを確認
+      expect(jupyterClient.clearAllOutputs).toHaveBeenCalledWith('analysis.ipynb');
+
+      // operateCell は呼ばれないこと
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+
+      // postAiEvent が all_outputs_cleared イベントで呼ばれたことを確認
+      expect(jupyterClient.postAiEvent).toHaveBeenCalledWith({
+        type: 'all_outputs_cleared',
+        notebook_path: 'analysis.ipynb',
+      });
+
+      expect(result.content[0].text).toContain('"success": true');
+      expect(result.content[0].text).toContain('"notebook_path": "analysis.ipynb"');
+    });
+
+    test('レスポンス形式確認（success フラグ、メッセージ）', async () => {
+      vi.mocked(jupyterClient.operateCell).mockResolvedValue(undefined);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookClearOutputs({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 0,
+      });
+
+      const responseText = result.content[0].text;
+      const responseJson = JSON.parse(responseText);
+
+      expect(responseJson.success).toBe(true);
+      expect(responseJson.notebook_path).toBe('analysis.ipynb');
+      expect(responseJson.cell_index).toBe(0);
+      expect(typeof responseJson.message).toBe('string');
+    });
+  });
+
+  describe('異常系 - バリデーションエラー', () => {
+    test('notebook_path 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookClearOutputs({});
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('notebook_path');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+      expect(jupyterClient.clearAllOutputs).not.toHaveBeenCalled();
+    });
+
+    test('パストラバーサル攻撃 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookClearOutputs({
+        notebook_path: '../../../etc/passwd',
+        cell_index: 0,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+
+    test('cell_index に非数値が指定された場合 => VALIDATION_ERROR', async () => {
+      const result = await executeNotebookClearOutputs({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 'abc',
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(jupyterClient.operateCell).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('異常系 - API エラー', () => {
+    test('単一セルクリアの API エラー', async () => {
+      const error = new Error('セルインデックスが不正です: 999');
+      (error as Record<string, unknown>).code = 'INVALID_CELL_INDEX';
+      vi.mocked(jupyterClient.operateCell).mockRejectedValue(error);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookClearOutputs({
+        notebook_path: 'analysis.ipynb',
+        cell_index: 999,
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('INVALID_CELL_INDEX');
+    });
+
+    test('全セルクリアの API エラー', async () => {
+      const error = new Error('ノートブックが見つかりません');
+      (error as Record<string, unknown>).code = 'NOTEBOOK_NOT_FOUND';
+      vi.mocked(jupyterClient.clearAllOutputs).mockRejectedValue(error);
+      vi.mocked(jupyterClient.postAiEvent).mockResolvedValue({ broadcasted: true, clients: 0 });
+
+      const result = await executeNotebookClearOutputs({
+        notebook_path: 'nonexistent.ipynb',
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('NOTEBOOK_NOT_FOUND');
+    });
+  });
+});

--- a/jupyter-server/extensions/custom_api/handlers.py
+++ b/jupyter-server/extensions/custom_api/handlers.py
@@ -905,6 +905,15 @@ class ContentsCellsHandler(BaseCustomHandler):
 
                 cells.insert(to_index, copied_cell)
 
+            elif action == "clear_output":
+                if not isinstance(index, int) or index < 0 or index >= len(cells):
+                    self.write_error_response("INVALID_CELL_INDEX", f"Invalid index: {index}", 400)
+                    return
+
+                if cells[index].get("cell_type") == "code":
+                    cells[index]["outputs"] = []
+                    cells[index]["execution_count"] = None
+
             else:
                 self.write_error_response("VALIDATION_ERROR", f"Unknown action: {action}", 400)
                 return
@@ -1234,6 +1243,55 @@ class ContentsCellExecuteHandler(BaseCustomHandler):
         )
 
 
+class ContentsCellsClearAllOutputsHandler(BaseCustomHandler):
+    """POST /api/custom/contents/{path}/cells/clear-all-outputs"""
+
+    @web.authenticated
+    async def post(self, path: str):
+        """全コードセルの出力をクリアする"""
+        try:
+            path = validate_path(path)
+        except ValueError as e:
+            self.write_error_response("VALIDATION_ERROR", str(e), 400)
+            return
+
+        if not path.endswith(".ipynb"):
+            self.write_error_response("VALIDATION_ERROR", "Not a notebook: path must end with .ipynb", 400)
+            return
+
+        try:
+            model = await self.contents_manager.get(path, content=True)
+        except FileNotFoundError:
+            self.write_error_response("NOTEBOOK_NOT_FOUND", f"Not found: {path}", 404)
+            return
+        except Exception as e:
+            log.error("Failed to load notebook '%s': %s", path, e, exc_info=True)
+            self.write_error_response("INTERNAL_ERROR", "Failed to load notebook", 500)
+            return
+
+        if model["type"] != "notebook":
+            self.write_error_response("VALIDATION_ERROR", "Not a notebook", 400)
+            return
+
+        cells = model["content"].get("cells", [])
+        cleared_cells = 0
+
+        for cell in cells:
+            if cell.get("cell_type") == "code":
+                cell["outputs"] = []
+                cell["execution_count"] = None
+                cleared_cells += 1
+
+        try:
+            await self.contents_manager.save(model, path)
+        except Exception as e:
+            log.error("Failed to save notebook '%s': %s", path, e, exc_info=True)
+            self.write_error_response("INTERNAL_ERROR", "Failed to save notebook", 500)
+            return
+
+        self.write_success({"cleared_cells": cleared_cells})
+
+
 class ContentsCellExecuteBatchHandler(BaseCustomHandler):
     """POST /api/custom/contents/{path}/cells/execute-batch"""
 
@@ -1428,6 +1486,7 @@ def get_handlers(base_url: str = ""):
         (f"{base_url}/api/custom/contents", ContentsListHandler),
         (f"{base_url}/api/custom/contents/(.*)/cells/([0-9]+)/execute", ContentsCellExecuteHandler),
         (f"{base_url}/api/custom/contents/(.*)/cells/execute-batch", ContentsCellExecuteBatchHandler),
+        (f"{base_url}/api/custom/contents/(.*)/cells/clear-all-outputs", ContentsCellsClearAllOutputsHandler),
         (f"{base_url}/api/custom/contents/(.*)/cells", ContentsCellsHandler),
         (f"{base_url}/api/custom/contents/(.*)/preview", ContentsPreviewHandler),
         (f"{base_url}/api/custom/contents/(.*)", ContentsHandler),

--- a/jupyter-server/tests/test_cell_clear_outputs.py
+++ b/jupyter-server/tests/test_cell_clear_outputs.py
@@ -1,0 +1,360 @@
+"""ContentsCellsHandler の clear_output アクションと
+ContentsCellsClearAllOutputsHandler のユニットテスト
+
+handlers.py の ContentsCellsHandler.patch() に clear_output アクションを追加し、
+ContentsCellsClearAllOutputsHandler.post() で全セル出力クリアを行う。
+ハンドラーの処理ロジックを直接インポートしてモックでテストする。
+
+テスト対象のアクションがまだ存在しないため（TDD Red フェーズ）、
+ハンドラーの存在確認とアクション実行結果のテストを行う。
+"""
+
+import importlib.util
+import sys
+import types as _types
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+_ext_dir = Path(__file__).resolve().parent.parent / "extensions"
+
+# --- 1. 重い依存のモック ---
+for _mod_name in ("pandas", "sqlalchemy", "sqlalchemy.exc", "tornado", "tornado.web"):
+    if _mod_name not in sys.modules:
+        _m = _types.ModuleType(_mod_name)
+        if _mod_name == "tornado.web":
+            _m.authenticated = lambda f: f
+        sys.modules[_mod_name] = _m
+
+# --- 2. custom_api パッケージ構造の構築 ---
+if "custom_api" not in sys.modules:
+    _pkg = _types.ModuleType("custom_api")
+    _pkg.__path__ = [str(_ext_dir / "custom_api")]
+    _pkg.__package__ = "custom_api"
+    sys.modules["custom_api"] = _pkg
+
+# base モジュールのモック
+if "custom_api.base" not in sys.modules:
+    _base_mock = _types.ModuleType("custom_api.base")
+    _base_mock.__package__ = "custom_api"
+    _base_mock.BaseCustomHandler = type("BaseCustomHandler", (), {})
+    _base_mock.resolve_workspace_dir = lambda *a, **kw: None
+    _base_mock.validate_timeout = lambda *a, **kw: (30, None)
+    _base_mock.validate_workspace_id = lambda *a, **kw: None
+    _base_mock.workspace_contents_path = lambda *a, **kw: ""
+    _base_mock.utc_now_iso = lambda: "2026-01-01T00:00:00Z"
+    _base_mock.WORKSPACE_ROOT_DIR = "/home/jovyan/work/workspaces/sample"
+    _base_mock.WORKSPACE_PATH_PREFIX = "workspaces/sample"
+    _base_mock.JUPYTER_ROOT_DIR = "/home/jovyan/work"
+    _base_mock.validate_kernel_name = lambda *a, **kw: None
+    sys.modules["custom_api.base"] = _base_mock
+
+# ai_events モジュールのモック
+if "custom_api.ai_events" not in sys.modules:
+    _ai_events_mock = _types.ModuleType("custom_api.ai_events")
+    _ai_events_mock.__package__ = "custom_api"
+    _ai_events_mock.AiEventsWebSocketHandler = type("AiEventsWebSocketHandler", (), {})
+    _ai_events_mock.AiEventsPostHandler = type("AiEventsPostHandler", (), {})
+    sys.modules["custom_api.ai_events"] = _ai_events_mock
+
+# code_validator モジュール（実際にロード — 純粋関数のため）
+if "custom_api.code_validator" not in sys.modules:
+    _cv_path = _ext_dir / "custom_api" / "code_validator.py"
+    _cv_spec = importlib.util.spec_from_file_location(
+        "custom_api.code_validator", _cv_path, submodule_search_locations=[]
+    )
+    _cv_mod = importlib.util.module_from_spec(_cv_spec)
+    _cv_mod.__package__ = "custom_api"
+    sys.modules["custom_api.code_validator"] = _cv_mod
+    _cv_spec.loader.exec_module(_cv_mod)
+
+# kernel_executor モジュールのモック
+if "custom_api.kernel_executor" not in sys.modules:
+    _ke_mock = _types.ModuleType("custom_api.kernel_executor")
+    _ke_mock.__package__ = "custom_api"
+    _ke_mock.KernelExecutor = MagicMock
+    sys.modules["custom_api.kernel_executor"] = _ke_mock
+
+# session_handlers モジュールのモック
+if "custom_api.session_handlers" not in sys.modules:
+    _sh_mock = _types.ModuleType("custom_api.session_handlers")
+    _sh_mock.__package__ = "custom_api"
+    _sh_mock.CustomSessionsHandler = type("CustomSessionsHandler", (), {})
+    _sh_mock.get_kernel_workspace = lambda *a: None
+    _sh_mock.unregister_kernel = lambda *a: None
+    sys.modules["custom_api.session_handlers"] = _sh_mock
+
+# sql_handlers モジュールのモック
+if "custom_api.sql_handlers" not in sys.modules:
+    _sql_mock = _types.ModuleType("custom_api.sql_handlers")
+    _sql_mock.__package__ = "custom_api"
+    _sql_mock.SqlExecuteHandler = type("SqlExecuteHandler", (), {})
+    _sql_mock.SqlExportHandler = type("SqlExportHandler", (), {})
+    sys.modules["custom_api.sql_handlers"] = _sql_mock
+
+# workspace_handlers モジュールのモック
+if "custom_api.workspace_handlers" not in sys.modules:
+    _wh_mock = _types.ModuleType("custom_api.workspace_handlers")
+    _wh_mock.__package__ = "custom_api"
+    _wh_mock.WorkspaceHandler = type("WorkspaceHandler", (), {})
+    _wh_mock.WorkspacesHandler = type("WorkspacesHandler", (), {})
+    _wh_mock.WorkspaceSummarizeHandler = type("WorkspaceSummarizeHandler", (), {})
+    sys.modules["custom_api.workspace_handlers"] = _wh_mock
+
+# --- 3. handlers モジュールをロード ---
+_module_path = _ext_dir / "custom_api" / "handlers.py"
+_handlers_spec = importlib.util.spec_from_file_location(
+    "custom_api.handlers",
+    _module_path,
+    submodule_search_locations=[],
+)
+_handlers = importlib.util.module_from_spec(_handlers_spec)
+_handlers.__package__ = "custom_api"
+sys.modules["custom_api.handlers"] = _handlers
+_handlers_spec.loader.exec_module(_handlers)
+
+ContentsCellsHandler = _handlers.ContentsCellsHandler
+
+
+# ============================================================
+# ヘルパー: ContentsCellsHandler のモックインスタンスを作成
+# ============================================================
+
+
+def _make_handler(cells: list[dict], path: str = "workspaces/sample/ws-001/test.ipynb"):
+    """ContentsCellsHandler のモックを作成し、patch() を呼べるようにする"""
+    handler = MagicMock(spec=ContentsCellsHandler)
+
+    model = {
+        "type": "notebook",
+        "content": {"cells": [dict(c) for c in cells]},
+    }
+
+    handler.get_json_body = MagicMock()
+    handler.contents_manager = MagicMock()
+    handler.contents_manager.get = AsyncMock(return_value=model)
+    handler.contents_manager.save = AsyncMock()
+
+    _responses = []
+    handler.write_success = MagicMock(side_effect=lambda d: _responses.append(("success", d)))
+    handler.write_error_response = MagicMock(
+        side_effect=lambda code, msg, status: _responses.append(("error", code, msg, status))
+    )
+    handler._responses = _responses
+    handler._model = model
+
+    return handler, path
+
+
+async def _call_patch(handler, path, body):
+    """handler.patch() をバインドして呼び出す"""
+    handler.get_json_body.return_value = body
+    await ContentsCellsHandler.patch(handler, path)
+
+
+# ============================================================
+# ヘルパー: ContentsCellsClearAllOutputsHandler のモックインスタンス
+# ============================================================
+
+
+def _make_clear_all_handler(cells: list[dict], path: str = "workspaces/sample/ws-001/test.ipynb"):
+    """ContentsCellsClearAllOutputsHandler のモックを作成し、post() を呼べるようにする"""
+    ContentsCellsClearAllOutputsHandler = _handlers.ContentsCellsClearAllOutputsHandler
+    handler = MagicMock(spec=ContentsCellsClearAllOutputsHandler)
+
+    model = {
+        "type": "notebook",
+        "content": {"cells": [dict(c) for c in cells]},
+    }
+
+    handler.contents_manager = MagicMock()
+    handler.contents_manager.get = AsyncMock(return_value=model)
+    handler.contents_manager.save = AsyncMock()
+
+    _responses = []
+    handler.write_success = MagicMock(side_effect=lambda d: _responses.append(("success", d)))
+    handler.write_error_response = MagicMock(
+        side_effect=lambda code, msg, status: _responses.append(("error", code, msg, status))
+    )
+    handler._responses = _responses
+    handler._model = model
+    handler._cls = ContentsCellsClearAllOutputsHandler
+
+    return handler, path
+
+
+async def _call_clear_all_post(handler, path):
+    """handler.post() をバインドして呼び出す"""
+    await handler._cls.post(handler, path)
+
+
+# ============================================================
+# clear_output 正常系テスト
+# ============================================================
+
+
+class TestClearOutputNormal:
+    """clear_output アクションの正常系テスト"""
+
+    @pytest.mark.asyncio
+    async def test_clear_output_code_cell(self):
+        """コードセルの出力クリア: outputs が [] に、execution_count が null になる"""
+        cells = [
+            {
+                "cell_type": "code",
+                "source": "print('hello')",
+                "outputs": [{"output_type": "stream", "text": "hello\n"}],
+                "execution_count": 5,
+            },
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "clear_output", "index": 0})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "success"
+
+        handler.contents_manager.save.assert_called_once()
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        changed_cells = saved_model["content"]["cells"]
+        assert len(changed_cells) == 1
+        assert changed_cells[0]["outputs"] == []
+        assert changed_cells[0]["execution_count"] is None
+        # source は変更されない
+        assert changed_cells[0]["source"] == "print('hello')"
+        assert changed_cells[0]["cell_type"] == "code"
+
+    @pytest.mark.asyncio
+    async def test_clear_output_markdown_cell(self):
+        """マークダウンセルに対しても正常に動作する（エラーにならない）"""
+        cells = [
+            {
+                "cell_type": "markdown",
+                "source": "# Title",
+            },
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "clear_output", "index": 0})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "success"
+
+
+# ============================================================
+# clear_output 異常系テスト
+# ============================================================
+
+
+class TestClearOutputError:
+    """clear_output アクションの異常系テスト"""
+
+    @pytest.mark.asyncio
+    async def test_clear_output_out_of_range_index(self):
+        """範囲外のインデックスでエラー"""
+        cells = [
+            {
+                "cell_type": "code",
+                "source": "a = 1",
+                "outputs": [],
+                "execution_count": None,
+            },
+        ]
+        handler, path = _make_handler(cells)
+        await _call_patch(handler, path, {"action": "clear_output", "index": 5})
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "error"
+
+
+# ============================================================
+# clear-all-outputs 正常系テスト
+# ============================================================
+
+
+class TestClearAllOutputsNormal:
+    """clear-all-outputs エンドポイントの正常系テスト"""
+
+    @pytest.mark.asyncio
+    async def test_clear_all_outputs_code_cells(self):
+        """全コードセルの outputs が [] に、execution_count が null になる"""
+        cells = [
+            {
+                "cell_type": "code",
+                "source": "print('hello')",
+                "outputs": [{"output_type": "stream", "text": "hello\n"}],
+                "execution_count": 1,
+            },
+            {
+                "cell_type": "code",
+                "source": "print('world')",
+                "outputs": [{"output_type": "stream", "text": "world\n"}],
+                "execution_count": 2,
+            },
+        ]
+        handler, path = _make_clear_all_handler(cells)
+        await _call_clear_all_post(handler, path)
+
+        assert len(handler._responses) == 1
+        assert handler._responses[0][0] == "success"
+
+        handler.contents_manager.save.assert_called_once()
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        changed_cells = saved_model["content"]["cells"]
+        assert len(changed_cells) == 2
+        for cell in changed_cells:
+            assert cell["outputs"] == []
+            assert cell["execution_count"] is None
+
+    @pytest.mark.asyncio
+    async def test_clear_all_outputs_skips_markdown_cells(self):
+        """マークダウンセルはスキップされ、コードセルのみクリアされる"""
+        cells = [
+            {
+                "cell_type": "code",
+                "source": "x = 1",
+                "outputs": [{"output_type": "stream", "text": "1\n"}],
+                "execution_count": 1,
+            },
+            {
+                "cell_type": "markdown",
+                "source": "# Title",
+            },
+            {
+                "cell_type": "code",
+                "source": "y = 2",
+                "outputs": [{"output_type": "stream", "text": "2\n"}],
+                "execution_count": 2,
+            },
+        ]
+        handler, path = _make_clear_all_handler(cells)
+        await _call_clear_all_post(handler, path)
+
+        assert len(handler._responses) == 1
+        resp = handler._responses[0]
+        assert resp[0] == "success"
+
+        handler.contents_manager.save.assert_called_once()
+        saved_model = handler.contents_manager.save.call_args[0][0]
+        changed_cells = saved_model["content"]["cells"]
+        # コードセルの出力がクリアされている
+        assert changed_cells[0]["outputs"] == []
+        assert changed_cells[0]["execution_count"] is None
+        assert changed_cells[2]["outputs"] == []
+        assert changed_cells[2]["execution_count"] is None
+        # マークダウンセルは変更されない
+        assert changed_cells[1]["cell_type"] == "markdown"
+        assert changed_cells[1]["source"] == "# Title"
+
+    @pytest.mark.asyncio
+    async def test_clear_all_outputs_empty_notebook(self):
+        """セルがない場合も正常終了する（cleared_cells: 0）"""
+        cells = []
+        handler, path = _make_clear_all_handler(cells)
+        await _call_clear_all_post(handler, path)
+
+        assert len(handler._responses) == 1
+        resp = handler._responses[0]
+        assert resp[0] == "success"
+        # レスポンスデータに cleared_cells: 0 が含まれること
+        success_data = resp[1]
+        assert success_data["cleared_cells"] == 0


### PR DESCRIPTION
## Summary
- `notebook_clear_outputs` MCPツールを実装（単一セル: `cell_index` 指定、全セル: `cell_index` 省略）
- jupyter-server に `PATCH /cells (action: clear_output)` と `POST /cells/clear-all-outputs` エンドポイントを追加
- リアルタイム同期イベント (`output_cleared`, `all_outputs_cleared`) を実装
- `ClearAllOutputsResponse` 型を `types.ts` に追加

## Test plan
- [x] jupyter-server ユニットテスト 6件（単一セルクリア正常系/異常系、全セルクリア正常系）
- [x] jupyter-mcp ユニットテスト 8件（正常系3件、バリデーション異常系3件、APIエラー異常系2件）
- [x] 全既存テスト通過（jupyter-server: 251, jupyter-mcp: 409）
- [x] lint + 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)
