### PR TITLE
feat: kernel_restart MCP ツール (タスク 19.5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,6 @@ Claude Desktop の設定ファイル（`claude_desktop_config.json`）に以下�
 | `notebook_copy_cell` | セルコピー |
 | `notebook_clear_outputs` | 出力クリア |
 | `kernel_restart` | カーネル再起動 |
-| `kernel_restart_and_run_all` | カーネル再起動+全セル実行 |
 | `kernel_interrupt` | カーネル中断 |
 | `file_list` | ファイル一覧取得 |
 | `file_read` | ファイル読み取り |

--- a/docs/plan/01-jupyter.md
+++ b/docs/plan/01-jupyter.md
@@ -229,6 +229,6 @@ SQLクエリ結果を大量行対応でワークスペースにファイル保�
 | 19.2 | セル結合・分割 | [x] | notebook_merge_cells で隣接セルが結合され、notebook_split_cell でセルが分割される | jupyter-server: PATCH /cells (action: merge/split)、jupyter-mcp: 2ツール |
 | 19.3 | セルタイプ変更・コピー | [x] | notebook_change_cell_type でセルタイプが変更され、notebook_copy_cell でセルが複製される | jupyter-server: PATCH /cells (action: change_type/copy)、jupyter-mcp: 2ツール |
 | 19.4 | 出力クリア | [x] | notebook_clear_outputs で単一セル/全セルの出力がクリアされる | jupyter-server: PATCH /cells (action: clear_output) + POST /cells/clear-all-outputs、jupyter-mcp: 1ツール |
-| 19.5 | カーネル再起動・再起動+全セル実行 | [→] | kernel_restart でカーネルが再起動され、kernel_restart_and_run_all で再起動後に全セルが実行される | jupyter-server: POST /restart-and-run-all、jupyter-mcp: 2ツール |
+| 19.5 | カーネル再起動 | [x] | kernel_restart でカーネルが再起動される。再起動+全セル実行は kernel_restart → notebook_execute_batch(mode: 'all') の順次呼び出しで実現 | jupyter-mcp: 1ツール |
 | 19.6 | カーネル中断（AI編集ロック貫通） | [ ] | kernel_interrupt で実行中のコードが中断される。AI編集ロック中でも中断可能で、MCP レスポンスに中断通知が含まれる | jupyter-server: interrupt API のロック貫通対応、jupyter-mcp: kernel_interrupt、jupyterlab-ai-sync: ロック中の中断ボタン有効化 |
 | 19.7 | ノートブック操作拡張の結合テスト | [ ] | 一括実行→結合→分割→タイプ変更→コピー→出力クリア→カーネル再起動の一連フローが動作する | 統合テスト |

--- a/docs/plan/01-jupyter.md
+++ b/docs/plan/01-jupyter.md
@@ -229,6 +229,6 @@ SQLクエリ結果を大量行対応でワークスペースにファイル保�
 | 19.2 | セル結合・分割 | [x] | notebook_merge_cells で隣接セルが結合され、notebook_split_cell でセルが分割される | jupyter-server: PATCH /cells (action: merge/split)、jupyter-mcp: 2ツール |
 | 19.3 | セルタイプ変更・コピー | [x] | notebook_change_cell_type でセルタイプが変更され、notebook_copy_cell でセルが複製される | jupyter-server: PATCH /cells (action: change_type/copy)、jupyter-mcp: 2ツール |
 | 19.4 | 出力クリア | [x] | notebook_clear_outputs で単一セル/全セルの出力がクリアされる | jupyter-server: PATCH /cells (action: clear_output) + POST /cells/clear-all-outputs、jupyter-mcp: 1ツール |
-| 19.5 | カーネル再起動・再起動+全セル実行 | [ ] | kernel_restart でカーネルが再起動され、kernel_restart_and_run_all で再起動後に全セルが実行される | jupyter-server: POST /restart-and-run-all、jupyter-mcp: 2ツール |
+| 19.5 | カーネル再起動・再起動+全セル実行 | [→] | kernel_restart でカーネルが再起動され、kernel_restart_and_run_all で再起動後に全セルが実行される | jupyter-server: POST /restart-and-run-all、jupyter-mcp: 2ツール |
 | 19.6 | カーネル中断（AI編集ロック貫通） | [ ] | kernel_interrupt で実行中のコードが中断される。AI編集ロック中でも中断可能で、MCP レスポンスに中断通知が含まれる | jupyter-server: interrupt API のロック貫通対応、jupyter-mcp: kernel_interrupt、jupyterlab-ai-sync: ロック中の中断ボタン有効化 |
 | 19.7 | ノートブック操作拡張の結合テスト | [ ] | 一括実行→結合→分割→タイプ変更→コピー→出力クリア→カーネル再起動の一連フローが動作する | 統合テスト |

--- a/docs/requirements/jupyter-mcp.md
+++ b/docs/requirements/jupyter-mcp.md
@@ -1011,34 +1011,6 @@ SQLクエリの結果をデータセットとしてワークスペースにフ�
 }
 ```
 
-### kernel_restart_and_run_all
-
-カーネルを再起動し、ノートブックの全コードセルを順番に実行する。
-
-```typescript
-{
-  name: "kernel_restart_and_run_all",
-  inputSchema: {
-    type: "object",
-    properties: {
-      notebook_path: {
-        type: "string",
-        description: "ノートブックのパス"
-      },
-      session_id: {
-        type: "string",
-        description: "セッションID"
-      },
-      timeout: {
-        type: "number",
-        description: "セルあたりのタイムアウト秒数"
-      }
-    },
-    required: ["notebook_path", "session_id"]
-  }
-}
-```
-
 ### kernel_interrupt
 
 実行中のコードを中断する。AI編集ロック中でも実行可能（ロック貫通）。中断された場合、実行中のMCPツール（execute_code等）のレスポンスに `interrupted: true` が含まれる。
@@ -1256,7 +1228,7 @@ npm run build && npm start
 
 ### AC14: カーネル制御
 - [ ] kernel_restart でカーネルが再起動され、変数がリセットされる
-- [ ] kernel_restart_and_run_all で再起動後に全セルが実行される
+- [ ] kernel_restart → notebook_execute_batch(mode: 'all') の順次呼び出しで再起動後に全セルが実行される
 - [ ] kernel_interrupt で実行中のコードが中断される
 - [ ] kernel_interrupt がAI編集ロック中でも実行できる
 - [ ] 中断された execute_code のレスポンスに interrupted 情報が含まれる

--- a/docs/tasks/jupyter/19.5-kernel-restart.md
+++ b/docs/tasks/jupyter/19.5-kernel-restart.md
@@ -1,0 +1,79 @@
+# タスク詳細: 19.5 カーネル再起動
+
+## 概要
+
+カーネルを再起動する `kernel_restart` MCP ツールを実装する。jupyter-server 側は既存の `POST /api/kernels/{kernel_id}/restart` と `client.ts` の `restartKernel()` メソッドをそのまま利用し、MCP ツールとして公開するのみ。「カーネル再起動+全セル実行」は AI が `kernel_restart` → `notebook_execute_batch(mode: 'all')` を順次呼び出すことで実現するため、専用ツールは作らない。
+
+## 関連ドキュメント
+
+- 要件定義: `docs/requirements/jupyter-server.md` の「F1.4: カーネル再起動」「AC12: カーネル制御」
+- 要件定義: `docs/requirements/jupyter-mcp.md` の「F3.3: カーネル制御」「AC14: カーネル制御」（ツール定義: L994-1012）
+- API仕様: `docs/design/api-contracts.md` の「カーネル管理」セクション（`POST /restart`）
+
+## 実装計画
+
+### 作成するファイル
+
+| ファイル | 内容 |
+|----------|------|
+| `jupyter-mcp/tests/unit/tools/kernel-restart.test.ts` | kernel_restart ツールのユニットテスト |
+| `jupyter-mcp/src/tools/kernel-restart.ts` | kernel_restart ツール実装 |
+
+### 修正するファイル
+
+| ファイル | 内容 |
+|----------|------|
+| `jupyter-mcp/src/tools/index.ts` | `kernel_restart` をtoolRegistryに追加 |
+| `jupyter-mcp/tests/unit/tools/index.test.ts` | ツール登録数を更新（+1） |
+
+### 実装手順
+
+#### 1. テスト作成（Red フェーズ）
+
+**`kernel-restart.test.ts`**:
+- 正常系: session_id 指定でカーネル再起動成功、レスポンスに kernel_id と status が含まれる
+- 異常系: session_id 未指定、セッション解決エラー、API エラー（カーネル未存在等）
+
+#### 2. ツール実装（Green フェーズ）
+
+**`kernel-restart.ts`**:
+- `session_id`（必須）を `validateStringParameter` で検証
+- `resolveKernelId(sessionId)` でカーネルID解決
+- `jupyterClient.restartKernel(kernelId)` で再起動（既存メソッド）
+- `createSuccessResponse({ kernel_id, status: "restarting" })` で返却
+
+#### 3. ツール登録
+
+**`tools/index.ts`**:
+- `kernel_restart` エントリ追加（inputSchema: `session_id` 必須）
+- `NOTEBOOK_EDIT_TOOLS` には追加しない（セル内容を変更しないため）
+
+**`index.test.ts`**: ツール登録数を +1 更新
+
+### 技術的な考慮事項
+
+- **既存コードの再利用**: `client.ts` の `restartKernel()` メソッドは既に実装済み。MCP ツールとしてのラッパーを追加するだけ
+- **sandbox 再注入**: `__init__.py` の `_wrap_restart_kernel` により、再起動時に自動的に sandbox コードが再注入される
+- **再起動+全セル実行**: AI が `kernel_restart` → `notebook_execute_batch(mode: 'all')` を順次呼び出すことで実現。カーネル再起動後のセル実行は Jupyter のカーネルプロトコルがメッセージをキューイングするため、明示的な待機は不要
+- **NOTEBOOK_EDIT_TOOLS 不要**: `kernel_restart` はセルの内容や出力を直接変更しないため、AI 編集ロックの対象外
+
+## 完了条件
+
+- [ ] `kernel_restart` ツールでカーネルが再起動され、変数・実行状態がリセットされる
+- [ ] 再起動後もセッションは維持される
+- [ ] jupyter-mcp のユニットテストが全て通る
+- [ ] ツール登録数テストが更新されている
+
+## テスト計画
+
+| コンポーネント | テストファイル | テスト数 | 内容 |
+|---------------|--------------|---------|------|
+| jupyter-mcp | `kernel-restart.test.ts` | ~5 | 正常系（再起動成功）、異常系（session_id未指定、解決エラー、APIエラー） |
+
+---
+
+## レビューステータス
+
+- [x] 計画レビュー完了
+- [ ] 実装完了
+- [ ] テスト完了

--- a/jupyter-mcp/CLAUDE.md
+++ b/jupyter-mcp/CLAUDE.md
@@ -46,7 +46,7 @@ npm run typecheck
 
 ## MCPツール一覧
 
-`workspace_create`, `workspace_list`, `workspace_update`, `workspace_summarize`, `session_create`, `session_list`, `session_connect`, `session_delete`, `execute_code`, `get_variables`, `get_dataframe_info`, `notebook_create`, `notebook_add_cell`, `notebook_list_cells`, `notebook_edit_cell`, `notebook_delete_cell`, `notebook_execute_cell`, `notebook_reorder_cell`, `notebook_execute_batch`, `notebook_merge_cells`, `notebook_split_cell`, `notebook_change_cell_type`, `notebook_copy_cell`, `notebook_clear_outputs`, `kernel_restart`, `kernel_restart_and_run_all`, `kernel_interrupt`, `file_list`, `file_read`, `data_preview`, `execute_sql`, `export_sql`, `get_image`
+`workspace_create`, `workspace_list`, `workspace_update`, `workspace_summarize`, `session_create`, `session_list`, `session_connect`, `session_delete`, `execute_code`, `get_variables`, `get_dataframe_info`, `notebook_create`, `notebook_add_cell`, `notebook_list_cells`, `notebook_edit_cell`, `notebook_delete_cell`, `notebook_execute_cell`, `notebook_reorder_cell`, `notebook_execute_batch`, `notebook_merge_cells`, `notebook_split_cell`, `notebook_change_cell_type`, `notebook_copy_cell`, `notebook_clear_outputs`, `kernel_restart`, `kernel_interrupt`, `file_list`, `file_read`, `data_preview`, `execute_sql`, `export_sql`, `get_image`
 
 > 各ツールの詳細は [docs/requirements/jupyter-mcp.md](../docs/requirements/jupyter-mcp.md) を参照。
 

--- a/jupyter-mcp/src/tools/index.ts
+++ b/jupyter-mcp/src/tools/index.ts
@@ -46,6 +46,7 @@ import { executeNotebookMergeCells } from './notebook-merge-cells.js';
 import { executeNotebookSplitCell } from './notebook-split-cell.js';
 import { executeNotebookChangeCellType } from './notebook-change-cell-type.js';
 import { executeNotebookCopyCell } from './notebook-copy-cell.js';
+import { executeKernelRestart } from './kernel-restart.js';
 import { executeNotebookClearOutputs } from './notebook-clear-outputs.js';
 
 const toolRegistry: ToolEntry<McpToolResult>[] = [
@@ -781,9 +782,28 @@ const toolRegistry: ToolEntry<McpToolResult>[] = [
     },
     execute: executeNotebookClearOutputs,
   },
+  {
+    definition: {
+      name: 'kernel_restart',
+      description:
+        'Restarts the kernel associated with the given session. All variables and state are cleared. To re-execute all cells after restart, call notebook_execute_batch(mode: "all") afterwards.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          session_id: {
+            type: 'string',
+            description: 'Session ID',
+          },
+        },
+        required: ['session_id'],
+      },
+    },
+    execute: executeKernelRestart,
+  },
 ];
 
-/** ノートブック編集系ツール: 実行前後に ai_edit_start/end イベントを自動配信する */
+/** ノートブック編集系ツール: 実行前後に ai_edit_start/end イベントを自動配信する
+ *  kernel_restart はセル内容を変更しないため対象外 */
 const NOTEBOOK_EDIT_TOOLS = new Set([
   'execute_code',
   'notebook_add_cell',

--- a/jupyter-mcp/src/tools/kernel-restart.ts
+++ b/jupyter-mcp/src/tools/kernel-restart.ts
@@ -1,0 +1,52 @@
+/**
+ * kernel_restart ツール実装
+ */
+
+import { jupyterClient } from '../jupyter-client/client.js';
+import {
+  createSuccessResponse,
+  createErrorResponse,
+  extractErrorCode,
+  extractErrorMessage,
+  type McpResponse,
+} from '../utils/response-formatter.js';
+import { validateStringParameter } from '../utils/validation.js';
+import { resolveKernelId } from '../utils/session-resolver.js';
+
+interface KernelRestartArgs {
+  session_id: string;
+}
+
+/**
+ * カーネルを再起動する
+ */
+export async function executeKernelRestart(args: Record<string, unknown>): Promise<McpResponse> {
+  const { session_id } = args as Partial<KernelRestartArgs>;
+
+  // 入力検証: session_id
+  const sessionIdValidation = validateStringParameter(session_id, 'session_id', {
+    required: true,
+    maxLength: 200,
+    allowEmpty: false,
+  });
+
+  if (!sessionIdValidation.isValid) {
+    return createErrorResponse(sessionIdValidation.errorMessage!, 'VALIDATION_ERROR');
+  }
+
+  const validatedSessionId = session_id as string;
+
+  try {
+    // session_id を kernel_id に解決
+    const kernelId = await resolveKernelId(validatedSessionId);
+
+    await jupyterClient.restartKernel(kernelId);
+
+    return createSuccessResponse({
+      kernel_id: kernelId,
+      status: 'restarting',
+    });
+  } catch (error) {
+    return createErrorResponse(extractErrorMessage(error), extractErrorCode(error));
+  }
+}

--- a/jupyter-mcp/tests/unit/tools/index.test.ts
+++ b/jupyter-mcp/tests/unit/tools/index.test.ts
@@ -104,6 +104,9 @@ vi.mock('../../../src/tools/notebook-copy-cell.js', () => ({
 vi.mock('../../../src/tools/notebook-clear-outputs.js', () => ({
   executeNotebookClearOutputs: vi.fn(async () => mockResponse('notebook_clear_outputs')),
 }));
+vi.mock('../../../src/tools/kernel-restart.js', () => ({
+  executeKernelRestart: vi.fn(async () => mockResponse('kernel_restart')),
+}));
 
 beforeEach(() => {
   mockEmitAiEditStart.mockClear();
@@ -113,7 +116,7 @@ beforeEach(() => {
 describe('registerTools', () => {
   test('全ツールが登録されている', () => {
     const tools = registerTools();
-    expect(tools).toHaveLength(30);
+    expect(tools).toHaveLength(31);
 
     const expectedToolNames = [
       'workspace_create',
@@ -146,6 +149,7 @@ describe('registerTools', () => {
       'notebook_change_cell_type',
       'notebook_copy_cell',
       'notebook_clear_outputs',
+      'kernel_restart',
     ];
 
     const toolNames = tools.map((t) => t.name);
@@ -216,6 +220,7 @@ describe('handleToolCall', () => {
     { toolName: 'execute_sql', args: { session_id: 'session-1', sql: 'SELECT 1', filename: 'test.csv' } },
     { toolName: 'export_sql', args: { session_id: 'session-1', sql: 'SELECT 1', filename: 'export.parquet' } },
     { toolName: 'get_image', args: { file_path: 'workspaces/ws-123/output/exec-1-img-001.png' } },
+    { toolName: 'kernel_restart', args: { session_id: 'session-1' } },
   ];
 
   toolRoutingTestCases.forEach(({ toolName, args }) => {

--- a/jupyter-mcp/tests/unit/tools/kernel-restart.test.ts
+++ b/jupyter-mcp/tests/unit/tools/kernel-restart.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { executeKernelRestart } from '../../../src/tools/kernel-restart.js';
+
+// jupyterClient と resolveKernelId をモック
+vi.mock('../../../src/jupyter-client/client.js', () => ({
+  jupyterClient: {
+    restartKernel: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/utils/session-resolver.js', () => ({
+  resolveKernelId: vi.fn(),
+}));
+
+import { jupyterClient } from '../../../src/jupyter-client/client.js';
+import { resolveKernelId } from '../../../src/utils/session-resolver.js';
+
+describe('executeKernelRestart', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(resolveKernelId).mockResolvedValue('kernel-abc');
+  });
+
+  describe('正常系', () => {
+    test('session_id 指定でカーネル再起動成功、kernel_id と status が返る', async () => {
+      vi.mocked(jupyterClient.restartKernel).mockResolvedValue({
+        id: 'kernel-abc',
+        name: 'python3',
+        status: 'starting',
+        started_at: '2026-04-08T00:00:00Z',
+      });
+
+      const result = await executeKernelRestart({
+        session_id: 'session-123',
+      });
+
+      // resolveKernelId が呼ばれたことを確認
+      expect(resolveKernelId).toHaveBeenCalledWith('session-123');
+
+      // restartKernel が正しい引数で呼ばれたことを確認
+      expect(jupyterClient.restartKernel).toHaveBeenCalledWith('kernel-abc');
+
+      // レスポンスに kernel_id と status が含まれることを確認
+      const responseText = result.content[0].text;
+      const responseJson = JSON.parse(responseText);
+      expect(responseJson.success).toBe(true);
+      expect(responseJson.kernel_id).toBe('kernel-abc');
+      expect(responseJson.status).toBe('restarting');
+    });
+  });
+
+  describe('異常系 - バリデーションエラー', () => {
+    test('session_id 未指定 => VALIDATION_ERROR', async () => {
+      const result = await executeKernelRestart({});
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('VALIDATION_ERROR');
+      expect(result.content[0].text).toContain('session_id');
+      expect(resolveKernelId).not.toHaveBeenCalled();
+      expect(jupyterClient.restartKernel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('異常系 - セッション解決エラー', () => {
+    test('セッションが見つからない場合 => エラーレスポンス', async () => {
+      const error = new Error('Session not found: session-999');
+      (error as Record<string, unknown>).code = 'SESSION_NOT_FOUND';
+      vi.mocked(resolveKernelId).mockRejectedValue(error);
+
+      const result = await executeKernelRestart({
+        session_id: 'session-999',
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('SESSION_NOT_FOUND');
+    });
+  });
+
+  describe('異常系 - API エラー', () => {
+    test('カーネル未存在等の API エラー => エラーレスポンス', async () => {
+      const error = new Error('Kernel not found: kernel-abc');
+      (error as Record<string, unknown>).code = 'KERNEL_NOT_FOUND';
+      vi.mocked(jupyterClient.restartKernel).mockRejectedValue(error);
+
+      const result = await executeKernelRestart({
+        session_id: 'session-123',
+      });
+
+      expect(result.content[0].text).toContain('"success": false');
+      expect(result.content[0].text).toContain('KERNEL_NOT_FOUND');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `kernel_restart` MCP ツールを実装（session_id を受け取り、カーネルを再起動）
- 既存の `jupyterClient.restartKernel()` メソッドを MCP ツールとして公開
- `kernel_restart_and_run_all` は専用ツールとせず、AI が `kernel_restart` → `notebook_execute_batch(mode: 'all')` を順次呼び出す方針に統一
- ドキュメントから `kernel_restart_and_run_all` の記載を削除し、コードと整合

## Test plan
- [x] `kernel_restart` ユニットテスト（正常系・異常系 4 件）通過
- [x] jupyter-mcp 全 414 テスト通過
- [x] lint / 型チェック通過
- [x] ツール登録数テスト更新済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)
