### PR TITLE
fix: allow-piped-commands.sh が settings.json も参照するよう修正

### DIFF
--- a/.claude/hooks/allow-piped-commands.sh
+++ b/.claude/hooks/allow-piped-commands.sh
@@ -28,39 +28,43 @@ if echo "$COMMAND" | grep -qE '\$\(|`'; then
   exit 0
 fi
 
-# settings.local.json から Bash の許可プレフィックスを動的に取得
-SETTINGS_FILE="${CLAUDE_PROJECT_DIR}/.claude/settings.local.json"
-if [[ ! -f "$SETTINGS_FILE" ]]; then
+# settings.json と settings.local.json の両方から Bash の許可プレフィックスを動的に取得
+SETTINGS_FILES=()
+for f in "${CLAUDE_PROJECT_DIR}/.claude/settings.json" "${CLAUDE_PROJECT_DIR}/.claude/settings.local.json"; do
+  [[ -f "$f" ]] && SETTINGS_FILES+=("$f")
+done
+
+if [[ ${#SETTINGS_FILES[@]} -eq 0 ]]; then
   exit 0
 fi
 
-# Bash(...) パターンからプレフィックスを抽出
+# 複数ファイルから Bash(...) パターンのプレフィックスを抽出・統合
 # "Bash(git status:*)" → "git status"
 # "Bash(scripts/*)" → "scripts/"
 # "Read", "Write" など Bash 以外はスキップ
+extract_prefixes() {
+  local jq_path="$1"
+  for f in "${SETTINGS_FILES[@]}"; do
+    jq -r "${jq_path}[]? // empty" "$f" 2>/dev/null
+  done | grep '^Bash(' \
+       | sed 's/^Bash(//; s/[:*]*)*$//' \
+       | sort -u
+}
+
 IFS=$'\n' read -r -d '' -a ALLOWED_PREFIXES < <(
-  jq -r '.permissions.allow[]? // empty' "$SETTINGS_FILE" \
-    | grep '^Bash(' \
-    | sed 's/^Bash(//; s/[:*]*)*$//' \
-    | sort -u
+  extract_prefixes '.permissions.allow'
   printf '\0'
 )
 
 # deny リストからブロック対象のプレフィックスも取得
 IFS=$'\n' read -r -d '' -a DENIED_PREFIXES < <(
-  jq -r '.permissions.deny[]? // empty' "$SETTINGS_FILE" \
-    | grep '^Bash(' \
-    | sed 's/^Bash(//; s/[:*]*)*$//' \
-    | sort -u
+  extract_prefixes '.permissions.deny'
   printf '\0'
 )
 
 # ask リストから確認対象のプレフィックスも取得
 IFS=$'\n' read -r -d '' -a ASK_PREFIXES < <(
-  jq -r '.permissions.ask[]? // empty' "$SETTINGS_FILE" \
-    | grep '^Bash(' \
-    | sed 's/^Bash(//; s/[:*]*)*$//' \
-    | sort -u
+  extract_prefixes '.permissions.ask'
   printf '\0'
 )
 


### PR DESCRIPTION
## Summary
- `allow-piped-commands.sh` が `settings.local.json` のみ参照していたため、`settings.json` に定義されたコマンド（`python3` 等）がパイプ付きで実行された際に許可が効かなかった
- 両ファイルを走査して許可プレフィックスを統合する `extract_prefixes` 関数を導入し、`allow` / `deny` / `ask` すべてのリストで共通化

## Test plan
- [x] 単体コマンド（パイプなし）→ passthrough（Claude Code の通常権限チェックに委ねる）
- [x] `settings.json` のみに定義されたコマンドのパイプ → allow
- [x] `settings.local.json` のみに定義されたコマンドのパイプ → allow
- [x] 両ファイルのコマンドを混在したパイプ → allow
- [x] 未許可コマンドを含むパイプ → passthrough
- [x] ask リストのコマンドを含むパイプ → passthrough
- [x] サブシェル含むコマンド → passthrough

🤖 Generated with [Claude Code](https://claude.com/claude-code)