### PR TITLE
feat: allow-piped-commands.sh で単純なサブシェルを解析して許可判定

### DIFF
--- a/.claude/hooks/allow-piped-commands.sh
+++ b/.claude/hooks/allow-piped-commands.sh
@@ -1,9 +1,15 @@
 #!/bin/bash
 
 # パイプ・チェーンで繋がれたコマンドを分解し、
-# 各コマンドが settings.local.json の許可リストに含まれていれば自動許可する hook
+# 各コマンドが settings.json / settings.local.json の許可リストに含まれていれば自動許可する hook
 #
-# 単体コマンド（パイプなし）は対象外 — Claude Code の通常の権限チェックに委ねる
+# サブシェル $() の扱い:
+#   - ネストした $() やバッククォート → 安全側に倒してスキップ
+#   - 単純な $() → 中身を取り出して許可リストと照合
+#   - 変数代入 VAR=$(...) → 代入自体は安全、$() 内のコマンドを検証
+#   - 変数参照 $VAR, "$VAR" → コマンド実行ではないのでスキップ
+#
+# 単体コマンド（パイプなし・サブシェルなし）は対象外 — Claude Code の通常の権限チェックに委ねる
 #
 # フック応答:
 #   JSON出力 + exit 0 = 明示的な許可/拒否
@@ -17,14 +23,20 @@ if [[ -z "$COMMAND" ]]; then
   exit 0
 fi
 
-# パイプ・チェーン演算子を含まない単体コマンドはスキップ
-# （Claude Code の allow list で処理される）
-if ! echo "$COMMAND" | grep -qE '\||\&\&|;'; then
+# バッククォートは安全側に倒してスキップ
+if echo "$COMMAND" | grep -q '`'; then
   exit 0
 fi
 
-# サブシェル $() やバッククォートは分割対象外（安全側に倒す）
-if echo "$COMMAND" | grep -qE '\$\(|`'; then
+# ネストした $() は安全側に倒してスキップ
+# 例: $(cmd1 $(cmd2)) — $( の後に ) が来る前に再度 $( が出現するパターン
+if echo "$COMMAND" | grep -qE '\$\([^)]*\$\('; then
+  exit 0
+fi
+
+# パイプ・チェーン演算子も $() も含まない単体コマンドはスキップ
+# （Claude Code の allow list で処理される）
+if ! echo "$COMMAND" | grep -qE '\||\&\&|;|\$\('; then
   exit 0
 fi
 
@@ -72,9 +84,63 @@ if [[ ${#ALLOWED_PREFIXES[@]} -eq 0 ]]; then
   exit 0
 fi
 
+# コマンド片を deny/ask/allow リストと照合する関数
+# 戻り値: 0=許可, 1=deny/ask に該当, 2=allow にマッチしない
+check_command_part() {
+  local part="$1"
+
+  for PREFIX in "${DENIED_PREFIXES[@]}"; do
+    [[ "$part" == "$PREFIX"* ]] && return 1
+  done
+
+  for PREFIX in "${ASK_PREFIXES[@]}"; do
+    [[ "$part" == "$PREFIX"* ]] && return 1
+  done
+
+  for PREFIX in "${ALLOWED_PREFIXES[@]}"; do
+    [[ "$part" == "$PREFIX"* ]] && return 0
+  done
+
+  return 2
+}
+
+# $() 内のコマンドを検証する
+# $() を含む場合、中身を取り出してパイプ/チェーンで分割し、各コマンドを照合する
+if echo "$COMMAND" | grep -qE '\$\('; then
+  # $(...) の中身を抽出（複数の $() に対応）
+  SUBSHELL_CONTENTS=$(echo "$COMMAND" | grep -oE '\$\([^)]+\)' | sed 's/^\$(//' | sed 's/)$//')
+
+  if [[ -n "$SUBSHELL_CONTENTS" ]]; then
+    while IFS= read -r SUBCMD; do
+      # サブシェル内もパイプ/チェーンで分割
+      IFS=$'\n' read -r -d '' -a SUB_PARTS < <(
+        echo "$SUBCMD" | sed 's/\s*|\s*/\n/g; s/\s*&&\s*/\n/g; s/\s*;\s*/\n/g'
+        printf '\0'
+      )
+
+      for SUB_PART in "${SUB_PARTS[@]}"; do
+        SUB_PART=$(echo "$SUB_PART" | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')
+        [[ -z "$SUB_PART" ]] && continue
+
+        check_command_part "$SUB_PART"
+        [[ $? -ne 0 ]] && exit 0
+      done
+    done <<< "$SUBSHELL_CONTENTS"
+  fi
+fi
+
+# メインコマンドの解析用に $() と $VAR をプレースホルダに置換
+CLEANED="$COMMAND"
+# $(...) → __SUBSHELL__ に置換
+CLEANED=$(echo "$CLEANED" | sed 's/\$([^)]*)/__SUBSHELL__/g')
+# "$VAR" → __VAR__ に置換（ダブルクォート付き変数参照）
+CLEANED=$(echo "$CLEANED" | sed 's/"\$[A-Za-z_][A-Za-z_0-9]*"/__VAR__/g')
+# $VAR → __VAR__ に置換（クォートなし変数参照）
+CLEANED=$(echo "$CLEANED" | sed 's/\$[A-Za-z_][A-Za-z_0-9]*/__VAR__/g')
+
 # コマンドを |, &&, ; で分割して配列に格納
 IFS=$'\n' read -r -d '' -a PARTS < <(
-  echo "$COMMAND" | sed 's/\s*|\s*/\n/g; s/\s*&&\s*/\n/g; s/\s*;\s*/\n/g'
+  echo "$CLEANED" | sed 's/\s*|\s*/\n/g; s/\s*&&\s*/\n/g; s/\s*;\s*/\n/g'
   printf '\0'
 )
 
@@ -86,33 +152,20 @@ for PART in "${PARTS[@]}"; do
     continue
   fi
 
-  # deny リストに該当する場合 → デフォルト動作に委ねる
-  for PREFIX in "${DENIED_PREFIXES[@]}"; do
-    if [[ "$PART" == "$PREFIX"* ]]; then
-      exit 0
+  # 変数代入パターン: VAR=value (コマンドなし) → 安全、スキップ
+  # 例: BRANCH=__SUBSHELL__ → 代入のみ、実行コマンドなし
+  if echo "$PART" | grep -qE '^[A-Za-z_][A-Za-z_0-9]*='; then
+    # 代入部分 (VAR=value) を除去して残りがあるか確認
+    AFTER_ASSIGN=$(echo "$PART" | sed 's/^[A-Za-z_][A-Za-z_0-9]*=[^ ]* *//')
+    if [[ -z "$AFTER_ASSIGN" ]]; then
+      continue  # 純粋な代入、コマンド実行なし
     fi
-  done
-
-  # ask リストに該当する場合 → デフォルト動作に委ねる
-  for PREFIX in "${ASK_PREFIXES[@]}"; do
-    if [[ "$PART" == "$PREFIX"* ]]; then
-      exit 0
-    fi
-  done
-
-  # allow リストでマッチするかチェック
-  MATCHED=false
-  for PREFIX in "${ALLOWED_PREFIXES[@]}"; do
-    if [[ "$PART" == "$PREFIX"* ]]; then
-      MATCHED=true
-      break
-    fi
-  done
-
-  if [[ "$MATCHED" == false ]]; then
-    # 未許可コマンドが含まれる → Claude Code のデフォルト動作に委ねる
-    exit 0
+    # VAR=value command args → command 部分を検証
+    PART="$AFTER_ASSIGN"
   fi
+
+  check_command_part "$PART"
+  [[ $? -ne 0 ]] && exit 0
 done
 
 # 全パーツが許可済み → 明示的に許可を返す


### PR DESCRIPTION
## Summary
- `allow-piped-commands.sh` で `$()` を含むコマンドを一律スキップしていたのを、単純な `$()` は中身を解析して許可判定するよう改善
- `VAR=$(cmd)` の変数代入、`$VAR` / `"$VAR"` の変数参照を適切に処理
- ネストした `$()` やバッククォートは引き続き安全側に倒してスキップ
- #42 の settings.json 参照対応と合わせて、`BRANCH=$(git branch --show-current) && git checkout dev && git pull origin dev && git branch -d "$BRANCH"` が許可なしで実行可能に

## Test plan
- [x] 単体コマンド（パイプなし）→ passthrough
- [x] パイプ付きコマンド → allow
- [x] `VAR=$(allowed_cmd) && allowed_cmd` → allow
- [x] `VAR=$(allowed_cmd | allowed_cmd)` → allow（サブシェル内パイプ）
- [x] `VAR=$(unknown_cmd)` → passthrough（サブシェル内に未許可コマンド）
- [x] ネストした `$()` → passthrough
- [x] バッククォート → passthrough
- [x] 未許可コマンドを含むパイプ → passthrough
- [x] ask リストのコマンド → passthrough
- [x] `"$VAR"` 変数参照 → コマンド実行として扱わない
- [x] 複数の非ネスト `$()` → allow
- [x] `VAR=$(cmd)` 単体（パイプなし）→ allow

🤖 Generated with [Claude Code](https://claude.com/claude-code)