### PR TITLE
fix: scripts/ 配下から直接実行した際の common.sh 解決エラーを修正

### DIFF
--- a/scripts/check-freshness.sh
+++ b/scripts/check-freshness.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-source "$(dirname "$0")/lib/common.sh"
+source scripts/lib/common.sh
 
 usage() {
   cat <<EOF

--- a/scripts/generate-init-scripts.sh
+++ b/scripts/generate-init-scripts.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-source "$(dirname "$0")/lib/common.sh"
+source scripts/lib/common.sh
 
 # --- usage ---
 usage() {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 cd "$(dirname "$0")/.."
-source "$(dirname "$0")/lib/common.sh"
+source scripts/lib/common.sh
 
 COMPONENTS=(jupyter-mcp document-mcp document-server jupyter-server)
 


### PR DESCRIPTION
## Summary

- `scripts/` ディレクトリから `./check-freshness.sh` 等を直接実行すると `./lib/common.sh: No such file or directory` エラーになっていたのを修正
- 原因: `cd "$(dirname "$0")/.."` 後に再度 `dirname "$0"` を評価していたため、cwd 変更後の `.` 基準で `common.sh` を探していた（`$0` の文字列処理なので `cd` 後は解決先がずれる）
- 対象 3 ファイル (`check-freshness.sh` / `generate-init-scripts.sh` / `test.sh`) を cwd 基準の `source scripts/lib/common.sh` に統一（`clean-rebuild.sh` / `rebuild.sh` / `switch-env.sh` と同じ書き方）

## Test plan

- [x] `cd scripts && ./check-freshness.sh` が正常動作すること
- [x] `cd scripts && ./test.sh --help` が正常動作すること
- [x] `cd scripts && ./generate-init-scripts.sh` が正常動作すること（引数エラーまで到達）
- [x] プロジェクトルートからの `scripts/check-freshness.sh` など従来の呼び出し方でも引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)
