### PR TITLE
fix: hook / script の jq 依存にフォールバックを追加

### DIFF
--- a/.claude/hooks/allow-piped-commands.sh
+++ b/.claude/hooks/allow-piped-commands.sh
@@ -16,8 +16,11 @@
 #   出力なし + exit 0 = 許可（デフォルト動作に委ねる）
 #   exit 2 = ブロック
 
+# shellcheck source=lib/json.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/json.sh"
+
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+COMMAND=$(json_get_path "$INPUT" .tool_input.command)
 
 if [[ -z "$COMMAND" ]]; then
   exit 0
@@ -55,9 +58,9 @@ fi
 # "Bash(scripts/*)" → "scripts/"
 # "Read", "Write" など Bash 以外はスキップ
 extract_prefixes() {
-  local jq_path="$1"
+  local json_path="$1"
   for f in "${SETTINGS_FILES[@]}"; do
-    jq -r "${jq_path}[]? // empty" "$f" 2>/dev/null
+    json_get_array_items "$f" "$json_path"
   done | grep '^Bash(' \
        | sed 's/^Bash(//; s/[:*]*)*$//' \
        | sort -u

--- a/.claude/hooks/block-direct-python.sh
+++ b/.claude/hooks/block-direct-python.sh
@@ -10,8 +10,11 @@ set -euo pipefail
 #   exit 0 = 許可（直叩きなし）
 #   exit 2 = ブロック（stderr の指示に従って Claude が自己修正）
 
+# shellcheck source=lib/json.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/json.sh"
+
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+COMMAND=$(json_get_path "$INPUT" .tool_input.command)
 
 if [[ -z "$COMMAND" ]]; then
   exit 0

--- a/.claude/hooks/block-heredoc-adhoc.sh
+++ b/.claude/hooks/block-heredoc-adhoc.sh
@@ -9,8 +9,11 @@
 #   exit 0 = 許可（heredoc なし、または対象外）
 #   exit 2 = ブロック（stderr の指示に従って Claude が自己修正）
 
+# shellcheck source=lib/json.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/json.sh"
+
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+COMMAND=$(json_get_path "$INPUT" .tool_input.command)
 
 if [[ -z "$COMMAND" ]]; then
   exit 0

--- a/.claude/hooks/block-main-commit.sh
+++ b/.claude/hooks/block-main-commit.sh
@@ -5,8 +5,11 @@
 # 対象: git commit を含む Bash コマンド
 # 動作: main ブランチにいる場合は exit 2 でブロック
 
+# shellcheck source=lib/json.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/json.sh"
+
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+COMMAND=$(json_get_path "$INPUT" .tool_input.command)
 
 if [[ -z "$COMMAND" ]]; then
   exit 0

--- a/.claude/hooks/check-before-test.sh
+++ b/.claude/hooks/check-before-test.sh
@@ -5,8 +5,11 @@
 # 対象: scripts/test.sh, scripts/smoke-test.sh
 # 例外: --rebuild フラグ付き（自前でリビルドするため）
 
+# shellcheck source=lib/json.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/json.sh"
+
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+COMMAND=$(json_get_path "$INPUT" .tool_input.command)
 
 if [[ -z "$COMMAND" ]]; then
   exit 0

--- a/.claude/hooks/explain-command.sh
+++ b/.claude/hooks/explain-command.sh
@@ -8,8 +8,11 @@
 # フック応答:
 #   出力なし + exit 0 = デフォルト動作に委ねる（許可判断には関与しない）
 
+# shellcheck source=lib/json.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/json.sh"
+
 INPUT=$(cat)
-DESCRIPTION=$(echo "$INPUT" | jq -r '.tool_input.description // empty')
+DESCRIPTION=$(json_get_path "$INPUT" .tool_input.description)
 
 if [[ -z "$DESCRIPTION" ]]; then
   exit 0

--- a/.claude/hooks/format-on-save.sh
+++ b/.claude/hooks/format-on-save.sh
@@ -10,9 +10,12 @@
 #   出力なし + exit 0 = 正常（デフォルト動作に委ねる）
 #   exit 2 = ブロック（使用しない）
 
+# shellcheck source=lib/json.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/json.sh"
+
 INPUT=$(cat)
-TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty')
-FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // empty')
+TOOL_NAME=$(json_get_path "$INPUT" .tool_name)
+FILE_PATH=$(json_get_path "$INPUT" .tool_input.file_path)
 
 # Edit / Write 以外は対象外
 if [[ "$TOOL_NAME" != "Edit" && "$TOOL_NAME" != "Write" ]]; then

--- a/.claude/hooks/lib/json.sh
+++ b/.claude/hooks/lib/json.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+# Hook 共有 JSON ユーティリティ。
+#
+# jq があれば jq を、なければ system python3 を使う。
+# hook 群が source して利用する。単体実行しない。
+#
+# フック自身はブートストラップ（`uv sync` 前）でも動く必要があるため、
+# ここでは `uv run python` ではなく system `python3` を呼ぶ。これは
+# `.claude/rules/python-uv.md` の意図的な例外（ハーネス側インフラ）。
+
+# json_get_path <json_string> <dot_path>
+#   ドット区切りパスの値を文字列で返す。見つからなければ空文字。
+#   例: json_get_path "$INPUT" .tool_input.command
+json_get_path() {
+  local json="$1"
+  local path="$2"
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$json" | jq -r "${path} // empty"
+  elif command -v python3 >/dev/null 2>&1; then
+    printf '%s' "$json" | HOOK_JSON_PATH="$path" python3 -c '
+import json, os, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+path = os.environ["HOOK_JSON_PATH"].lstrip(".")
+value = data
+if path:
+    for key in path.split("."):
+        if isinstance(value, dict):
+            value = value.get(key)
+        else:
+            value = None
+            break
+if value is None:
+    sys.stdout.write("")
+elif isinstance(value, str):
+    sys.stdout.write(value)
+else:
+    sys.stdout.write(json.dumps(value))
+'
+  else
+    echo "ERROR: jq も python3 も利用できないため JSON をパースできません" >&2
+    return 1
+  fi
+}
+
+# json_get_array_items <file> <dot_path>
+#   ファイル内の JSON を読み、ドット区切りパスが指す配列要素を 1 行ずつ出力する。
+#   文字列要素のみ対応（オブジェクト/配列要素は JSON 文字列化して出力）。
+#   ファイルが存在しない/パスが配列でない場合は無出力で終了コード 0 を返す。
+json_get_array_items() {
+  local file="$1"
+  local path="$2"
+  [[ -f "$file" ]] || return 0
+  if command -v jq >/dev/null 2>&1; then
+    jq -r "${path}[]? // empty" "$file" 2>/dev/null
+  elif command -v python3 >/dev/null 2>&1; then
+    HOOK_JSON_PATH="$path" python3 -c '
+import json, os, sys
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+path = os.environ["HOOK_JSON_PATH"].lstrip(".")
+value = data
+if path:
+    for key in path.split("."):
+        if isinstance(value, dict):
+            value = value.get(key)
+        else:
+            value = None
+            break
+if isinstance(value, list):
+    for item in value:
+        if item is None:
+            continue
+        if isinstance(item, str):
+            print(item)
+        else:
+            print(json.dumps(item))
+' "$file" 2>/dev/null
+  else
+    return 1
+  fi
+}
+
+# json_emit_ask <reason>
+#   PreToolUse の "ask" 決定 JSON を標準出力に出す。
+json_emit_ask() {
+  local reason="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --arg reason "$reason" '{
+      hookSpecificOutput: {
+        hookEventName: "PreToolUse",
+        permissionDecision: "ask",
+        permissionDecisionReason: $reason
+      }
+    }'
+  elif command -v python3 >/dev/null 2>&1; then
+    HOOK_REASON="$reason" python3 -c '
+import json, os
+print(json.dumps({
+  "hookSpecificOutput": {
+    "hookEventName": "PreToolUse",
+    "permissionDecision": "ask",
+    "permissionDecisionReason": os.environ["HOOK_REASON"]
+  }
+}, ensure_ascii=False))
+'
+  else
+    return 1
+  fi
+}

--- a/.claude/hooks/scan-adhoc-script.sh
+++ b/.claude/hooks/scan-adhoc-script.sh
@@ -11,8 +11,11 @@
 #   exit 0 = 許可（対象外、または危険パターンなし）
 #   JSON + exit 0 = ask（危険パターン検出、ユーザー承認を要求）
 
+# shellcheck source=lib/json.sh
+. "$(dirname "${BASH_SOURCE[0]}")/lib/json.sh"
+
 INPUT=$(cat)
-COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+COMMAND=$(json_get_path "$INPUT" .tool_input.command)
 
 if [[ -z "$COMMAND" ]]; then
   exit 0
@@ -82,12 +85,5 @@ fi
 REASONS=$(printf '%s; ' "${DETECTED[@]}")
 MESSAGE="tmp/ スクリプト '${SCRIPT_PATH}' に禁止パターンが検出されました: ${REASONS}詳細は .claude/rules/adhoc-script-execution.md を参照してください。"
 
-# jq で JSON をエスケープして出力
-jq -n --arg reason "$MESSAGE" '{
-  hookSpecificOutput: {
-    hookEventName: "PreToolUse",
-    permissionDecision: "ask",
-    permissionDecisionReason: $reason
-  }
-}'
+json_emit_ask "$MESSAGE"
 exit 0

--- a/.claude/hooks/tests/block-direct-python.test.sh
+++ b/.claude/hooks/tests/block-direct-python.test.sh
@@ -21,8 +21,12 @@ run_test() {
   local command="$2"
   local expected_exit="$3"
 
+  # 入力 JSON は python3 で組み立てる（jq 未インストール環境でもテストを回すため）
   local input
-  input=$(printf '{"tool_input":{"command":%s}}' "$(printf '%s' "$command" | jq -Rs .)")
+  input=$(HOOK_TEST_COMMAND="$command" python3 -c '
+import json, os
+print(json.dumps({"tool_input": {"command": os.environ["HOOK_TEST_COMMAND"]}}))
+')
 
   local actual_exit=0
   echo "$input" | "$HOOK" >/dev/null 2>&1 || actual_exit=$?

--- a/.claude/hooks/tests/json-lib.test.sh
+++ b/.claude/hooks/tests/json-lib.test.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# .claude/hooks/lib/json.sh のテスト
+# 実行: bash .claude/hooks/tests/json-lib.test.sh
+#
+# jq が利用可能なら jq パスと python3 フォールバックパスの両方を検証する。
+# jq が未インストールなら python3 パスのみ検証する。
+
+set -euo pipefail
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(git rev-parse --show-toplevel)}"
+LIB="${PROJECT_DIR}/.claude/hooks/lib/json.sh"
+
+if [[ ! -f "$LIB" ]]; then
+  echo "ERROR: lib not found: $LIB" >&2
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+. "$LIB"
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+assert_eq() {
+  local desc="$1"
+  local expected="$2"
+  local actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "  PASS: $desc"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $desc"
+    echo "    expected: $(printf %q "$expected")"
+    echo "    actual:   $(printf %q "$actual")"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$desc")
+  fi
+}
+
+run_suite() {
+  local label="$1"
+  echo ""
+  echo "=== $label ==="
+
+  # json_get_path: ネストしたドットパス
+  local out
+  out=$(json_get_path '{"tool_input":{"command":"echo hi"}}' .tool_input.command)
+  assert_eq "${label}: .tool_input.command → \"echo hi\"" "echo hi" "$out"
+
+  # json_get_path: トップレベル
+  out=$(json_get_path '{"tool_name":"Bash"}' .tool_name)
+  assert_eq "${label}: .tool_name → \"Bash\"" "Bash" "$out"
+
+  # json_get_path: キー欠損 → 空文字列
+  out=$(json_get_path '{"tool_input":{}}' .tool_input.command)
+  assert_eq "${label}: 欠損キー → 空文字" "" "$out"
+
+  # json_get_path: パス途中が null → 空文字列
+  out=$(json_get_path '{"tool_input":null}' .tool_input.command)
+  assert_eq "${label}: null 中間 → 空文字" "" "$out"
+
+  # json_get_path: 空 JSON → 空文字列
+  out=$(json_get_path '{}' .tool_input.command)
+  assert_eq "${label}: 空 JSON → 空文字" "" "$out"
+
+  # json_get_path: クォート含むコマンド
+  out=$(json_get_path '{"tool_input":{"command":"echo \"hi\""}}' .tool_input.command)
+  assert_eq "${label}: クォート付きコマンド" 'echo "hi"' "$out"
+
+  # json_get_array_items: 配列読み取り
+  local tmpfile
+  tmpfile=$(mktemp)
+  printf '%s' '{"permissions":{"allow":["Read","Bash(git:*)","Write"]}}' > "$tmpfile"
+  local items
+  items=$(json_get_array_items "$tmpfile" .permissions.allow | tr '\n' '|')
+  assert_eq "${label}: 配列要素 3 個" "Read|Bash(git:*)|Write|" "$items"
+
+  # json_get_array_items: 配列なし → 空
+  printf '%s' '{"permissions":{}}' > "$tmpfile"
+  items=$(json_get_array_items "$tmpfile" .permissions.allow)
+  assert_eq "${label}: 配列欠損 → 空" "" "$items"
+
+  # json_get_array_items: ファイル非存在 → 空
+  items=$(json_get_array_items "/nonexistent/file.json" .permissions.allow)
+  assert_eq "${label}: ファイル非存在 → 空" "" "$items"
+
+  rm -f "$tmpfile"
+
+  # json_emit_ask: 出力 JSON に reason が含まれる
+  local ask_out
+  ask_out=$(json_emit_ask "テスト用メッセージ")
+  if printf '%s' "$ask_out" | grep -q 'テスト用メッセージ' \
+    && printf '%s' "$ask_out" | grep -q '"permissionDecision"' \
+    && printf '%s' "$ask_out" | grep -q '"ask"'; then
+    echo "  PASS: ${label}: json_emit_ask"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: ${label}: json_emit_ask"
+    echo "    output: $ask_out"
+    FAIL=$((FAIL + 1))
+    FAILURES+=("${label}: json_emit_ask")
+  fi
+}
+
+# python3 フォールバックパスを強制するため、PATH から jq を隠す
+FAKE_PATH_DIR=$(mktemp -d)
+trap 'rm -rf "$FAKE_PATH_DIR"' EXIT
+
+# 1. jq が利用可能ならまず jq パスを検証
+if command -v jq >/dev/null 2>&1; then
+  run_suite "jq パス"
+else
+  echo ""
+  echo "=== jq パス（jq 未インストールのためスキップ）==="
+fi
+
+# 2. python3 パスを強制検証:
+#    PATH を /usr/bin:/bin のみにし、空の FAKE_PATH_DIR を先頭に置くことで jq を隠す
+if command -v python3 >/dev/null 2>&1; then
+  OLD_PATH="$PATH"
+  # jq のパスを意図的に外した最小 PATH
+  export PATH="$FAKE_PATH_DIR:/usr/bin:/bin"
+  if command -v jq >/dev/null 2>&1; then
+    echo ""
+    echo "WARNING: 制限 PATH でも jq が見えてしまったため python3 フォールバックは未検証"
+  else
+    run_suite "python3 フォールバックパス"
+  fi
+  export PATH="$OLD_PATH"
+else
+  echo ""
+  echo "=== python3 フォールバック（python3 なしのためスキップ）==="
+fi
+
+echo ""
+echo "=== 結果 ==="
+echo "PASS: $PASS, FAIL: $FAIL"
+
+if [[ $FAIL -gt 0 ]]; then
+  echo "失敗ケース:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+
+echo "全テスト PASS"

--- a/scripts/manage-known-failures.sh
+++ b/scripts/manage-known-failures.sh
@@ -3,6 +3,18 @@ set -euo pipefail
 
 cd "$(dirname "$0")/.."
 
+if ! command -v jq >/dev/null 2>&1; then
+  cat >&2 <<'EOF'
+ERROR: jq がインストールされていません。
+
+このスクリプトは known-failures.json の JSON CRUD に jq を必要とします。
+インストール:
+  Debian/Ubuntu: sudo apt-get install -y jq
+  macOS:         brew install jq
+EOF
+  exit 1
+fi
+
 KF_FILE="tests/known-failures.json"
 
 usage() {

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -308,6 +308,10 @@ if [[ ${#FAILED[@]} -eq 0 ]]; then
   echo "All targets passed."
 else
   if $HEALTH; then
+    if ! command -v jq >/dev/null 2>&1; then
+      echo "ERROR: --health は jq を必要とします。sudo apt-get install -y jq / brew install jq でインストールしてください。" >&2
+      exit 1
+    fi
     # Classify failures against known-failures.json
     KF_FILE="tests/known-failures.json"
     KNOWN=()


### PR DESCRIPTION
## Summary

- jq 未インストール環境で全 8 個の Claude Code hook が `exit 127` で silent fail していた問題を修正
- `.claude/hooks/lib/json.sh` に jq → system python フォールバック付きの JSON パース/出力ユーティリティを集約し、8 hook をこれ経由に書き換え
- hook は clone 直後（`uv sync` 前）にも動く必要があるため、`uv run` ではなく system python を呼ぶ意図的な例外とした（lib のコメントに明記）
- `manage-known-failures.sh` と `scripts/test.sh --health` は jq を代替しにくいため、jq 未検出時に明示的な案内エラーを出すよう早期チェックを追加
- テスト追加: `json-lib.test.sh`（jq パス / python フォールバックパスの両方）
- `block-direct-python.test.sh` の入力 JSON 組み立ても jq→python に置換し、テスト自身も jq なし環境で回るようにした

## 背景

WSL2 の開発環境で `command -v jq` が失敗することが判明。`.claude/settings.json` で登録されている 7 個の PreToolUse Bash hook + 1 個の PostToolUse Edit/Write hook がすべて `jq: command not found` で exit 127 していた（hook は exit 2 以外なら Claude Code は実行を継続するため、事実上すべての hook 保護が無効化されていた）。

同時にスクリプト監査を実施し、他に `.env` 未存在時のサイレント失敗や `uv` PATH 反映遅延など、clone 直後に壊れうる箇所を確認済み。これらはタスク 9.4（初回セットアップスクリプト）の本来スコープに属するため本 PR には含めない。

## 対象外（次のタスクで扱う）

- `.env` の bootstrap（9.4）
- `uv` PATH 反映の検証（9.4）
- `date -d` の BSD/GNU 差分、`curl` 依存の明示化（pre-existing、優先度低）

## Test plan

- [x] `bash .claude/hooks/tests/json-lib.test.sh` — 10 ケース PASS
- [x] `bash .claude/hooks/tests/block-direct-python.test.sh` — 17 ケース PASS（既存）
- [x] 全 8 hook を無害な入力で叩き、exit 0 が返ることを手動確認
- [x] `bash scripts/manage-known-failures.sh list` で明示的な jq インストール案内が出ることを確認
- [ ] CI グリーン確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
