### PR TITLE
docs: Claude Desktop 接続設定の古いトークン記述を修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ docker-compose up -d
 
 JupyterLab にはブラウザで `http://localhost:8888?token=<JUPYTER_TOKEN>` でアクセスできます。
 
-### 5. MCPサーバーのビルド
+### 4. MCPサーバーのビルド
 
 MCPサーバー（jupyter-mcp, document-mcp）は Claude Desktop からローカルプロセスとして起動されるため、docker-compose には含まれません。事前にビルドしておきます。
 
@@ -77,9 +77,16 @@ cd document-mcp && npm install && cd ..
 scripts/rebuild-mcp.sh document-mcp
 ```
 
-### 6. Claude Desktop への接続設定
+### 5. Claude Desktop への接続設定
 
-Claude Desktop の設定ファイル（`claude_desktop_config.json`）に以下を追加してください:
+Claude Desktop の設定ファイル `claude_desktop_config.json` を開きます（Claude Desktop メニュー → `Settings` → `Developer` → `Edit Config`）。設定ファイルのパスは OS により異なります:
+
+| OS | パス |
+|----|------|
+| macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
+| Windows / WSL | `%APPDATA%\Claude\claude_desktop_config.json` |
+
+`mcpServers` に以下のエントリを追加してください:
 
 ```json
 {
@@ -89,21 +96,44 @@ Claude Desktop の設定ファイル（`claude_desktop_config.json`）に以下�
       "args": ["<absolute-path-to>/jupyter-mcp/dist/index.js"],
       "env": {
         "JUPYTER_SERVER_URL": "http://localhost:8888",
-        "JUPYTER_TOKEN": "<your-jupyter-token>"
+        "JUPYTER_TOKEN": "<JUPYTER_TOKEN>"
       }
     },
     "document-mcp": {
       "command": "node",
       "args": ["<absolute-path-to>/document-mcp/dist/index.js"],
       "env": {
-        "DOCUMENT_SERVER_URL": "http://localhost:3002"
+        "DOCUMENT_SERVER_URL": "http://localhost:3002",
+        "DOCUMENT_SERVER_TOKEN": "<DOCUMENT_SERVER_TOKEN>"
       }
     }
   }
 }
 ```
 
-`<absolute-path-to>` と `<your-jupyter-token>` は実際の値に置き換えてください。
+置換ポイント:
+
+- `<absolute-path-to>` — プロジェクトの絶対パス
+- `<JUPYTER_TOKEN>` / `<DOCUMENT_SERVER_TOKEN>` — プロジェクト直下の `.env` の同名変数と**完全一致**させる（不一致だと 401 になる）
+
+**WSL の場合**: Claude Desktop は Windows プロセスのため、Linux パスと Linux 側 `node` を直接指定すると失敗します。`wsl.exe` 経由で起動してください:
+
+```json
+{
+  "mcpServers": {
+    "jupyter-mcp": {
+      "command": "wsl.exe",
+      "args": ["node", "/home/<user>/path/to/jupyter-mcp/dist/index.js"],
+      "env": {
+        "JUPYTER_SERVER_URL": "http://localhost:8888",
+        "JUPYTER_TOKEN": "<JUPYTER_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+保存後、Claude Desktop を完全終了（macOS: Cmd+Q / Windows: タスクトレイから終了）してから再起動し、ハンマーアイコンに両サーバーのツールが表示されれば成功です。
 
 ## MCPツール一覧
 

--- a/jupyter-mcp/docs/claude-desktop-setup.md
+++ b/jupyter-mcp/docs/claude-desktop-setup.md
@@ -1,134 +1,28 @@
-# Claude Desktop 接続設定ガイド
+# Claude Desktop 接続動作確認ガイド
 
-このドキュメントでは、Claude Desktop から jupyter-mcp に接続する方法を説明します。
-
-## 前提条件
-
-以下の環境が準備されていることを確認してください：
-
-- **Node.js**: v18 以上がインストールされていること
-- **Claude Desktop**: 最新版がインストールされていること
-- **jupyter-server**: Docker で起動していること
-- **jupyter-mcp**: ビルド済みであること
+Claude Desktop から jupyter-mcp に接続した後の動作確認手順とトラブルシューティングをまとめたドキュメントです。
 
 ## セットアップ手順
 
-### 1. jupyter-server の起動
+接続設定（`claude_desktop_config.json` の編集方法・WSL 向け起動パターン・必要な環境変数）は [プロジェクト README の「5. Claude Desktop への接続設定」](../../README.md#5-claude-desktop-への接続設定) を参照してください。
 
-```bash
-cd jupyter-server
-docker-compose up -d
-```
-
-起動確認:
-```bash
-docker-compose ps
-# jupyter-server が Up 状態であることを確認
-```
-
-### 2. jupyter-mcp のビルド
-
-```bash
-cd jupyter-mcp
-npm install
-npm run build
-```
-
-ビルド成果物の確認:
-```bash
-ls dist/index.js
-# ファイルが存在することを確認
-```
-
-### 3. Claude Desktop の設定ファイル編集
-
-Claude Desktop の設定ファイルを編集します。
-
-**ファイルパス（macOS）:**
-```
-~/Library/Application Support/Claude/claude_desktop_config.json
-```
-
-**ファイルパス（Windows）:**
-```
-%APPDATA%\Claude\claude_desktop_config.json
-```
-
-**設定内容:**
-
-```json
-{
-  "mcpServers": {
-    "jupyter-mcp": {
-      "command": "node",
-      "args": ["{プロジェクトの絶対パス}/jupyter-mcp/dist/index.js"],
-      "env": {
-        "JUPYTER_SERVER_URL": "http://localhost:8888",
-        "JUPYTER_TOKEN": "test-token-123"
-      }
-    }
-  }
-}
-```
-
-**重要:**
-- `{プロジェクトの絶対パス}` を実際のパスに置き換えてください
-  - 例: `/Users/yourname/projects/ai-data-analysis-platform`
-- 既存の設定がある場合は、`mcpServers` オブジェクトに追記してください
-- `JUPYTER_TOKEN` の値は `jupyter-server/docker-compose.yml` の `JUPYTER_TOKEN` 環境変数と一致させてください
-
-### 4. Claude Desktop の再起動
-
-設定ファイルを変更したら、Claude Desktop を完全に再起動してください。
-
-**macOS:**
-```
-1. Cmd + Q でアプリを終了
-2. Claude Desktop を再度起動
-```
-
-**Windows:**
-```
-1. Alt + F4 でアプリを終了
-2. Claude Desktop を再度起動
-```
-
-### 5. 接続確認
-
-Claude Desktop のチャット画面で以下を確認してください：
-
-1. **ツールアイコンの表示**
-   - 画面下部の入力欄付近にハンマーアイコンが表示される
-
-2. **ツール一覧の確認**
-   - ハンマーアイコンをクリック
-   - `jupyter-mcp` の 11 個のツールが一覧に表示される
-     - `notebook_create`
-     - `notebook_add_cell`
-     - `session_create`
-     - `session_list`
-     - `session_delete`
-     - `session_connect`
-     - `execute_code`
-     - `get_variables`
-     - `get_dataframe_info`
-     - `file_list`
-     - `get_image_resource`
+接続後、Claude Desktop のチャット画面下部にハンマーアイコンが表示され、クリックすると `jupyter-mcp` のツールが一覧できれば接続成功です。提供ツールの一覧は [`docs/requirements/jupyter-mcp.md`](../../docs/requirements/jupyter-mcp.md) を参照してください。
 
 ## 動作確認テスト
 
-Claude Desktop で以下のプロンプトを送信して、正しく動作することを確認してください。
+Claude Desktop で以下のプロンプトを順に送信し、AI がツールを自律的に選択・実行することを確認します。
 
-### テスト 1: 基本的なコード実行
+### テスト 1: セッション作成とコード実行
 
 ```
 新しい分析セッションを作成して、Pythonで「Hello from Claude Desktop」と表示してください。
 ```
 
-**期待される動作:**
-- Claude が `session_create` を自動で呼び出す
-- Claude が `execute_code` でコードを実行する
-- 「Hello from Claude Desktop」が表示される
+確認ポイント:
+
+- `session_create` が呼ばれる
+- `execute_code` が呼ばれる
+- 実行結果に「Hello from Claude Desktop」が含まれる
 
 ### テスト 2: データ分析
 
@@ -139,147 +33,75 @@ pandasでサンプルデータを作成して分析してください。
 - 基本統計量の確認
 ```
 
-**期待される動作:**
-- Claude がデータ生成コードを実行する
-- Claude が `get_variables` や `get_dataframe_info` でデータを確認する
-- 分析結果が表示される
+確認ポイント:
 
-### テスト 3: グラフ描画
+- `execute_code` でデータ生成・集計コードが実行される
+- `get_variables` / `get_dataframe_info` で DataFrame 構造が確認される
+
+### テスト 3: グラフ描画と画像認識
 
 ```
-先ほどのデータを使って、カテゴリ別の金額を棒グラフで可視化してください。
+先ほどのデータを使って、カテゴリ別の金額を棒グラフで可視化してください。グラフの内容を説明してください。
 ```
 
-**期待される動作:**
-- Claude が matplotlib でグラフを描画する
-- Claude が `get_image_resource` で画像を取得する
-- グラフが表示され、Claude が内容を説明する
+確認ポイント:
+
+- `execute_code` で matplotlib 描画コードが実行される
+- `get_image` 経由で画像データが取得される
+- Claude が画像の内容を自然言語で説明する
+
+### テスト 4: エラーハンドリング
+
+```
+1/0 を計算するPythonコードを実行してください。
+```
+
+確認ポイント:
+
+- `execute_code` の結果に `ZeroDivisionError` が含まれる
+- Claude がエラー内容を説明する
+
+### テスト 5: セッション管理
+
+```
+現在のセッション一覧を確認して、不要なセッションがあれば削除してください。
+```
+
+確認ポイント:
+
+- `session_list` で一覧取得
+- `session_delete` で削除
+- 再度 `session_list` で削除結果を確認
 
 ## トラブルシューティング
 
 ### ツールが表示されない
 
-**原因:**
-- 設定ファイルのパスが間違っている
-- 設定ファイルの JSON 形式が不正
-- Claude Desktop の再起動が不完全
+- Claude Desktop の `Settings → Developer → MCP servers` にエラーが出ていないか確認する
+- `claude_desktop_config.json` の JSON 構文エラー（カンマ・クォート）を確認する
+- `args` のパスが絶対パスか、対象ファイルが実在するか確認する
+- Claude Desktop を**完全終了**してから再起動する（プロセスが常駐していると設定が再読み込みされない）
 
-**対処法:**
-1. 設定ファイルのパスを確認する
-   ```bash
-   # macOS
-   cat ~/Library/Application\ Support/Claude/claude_desktop_config.json
+### ツールはあるが認証に失敗する（401）
 
-   # Windows
-   type %APPDATA%\Claude\claude_desktop_config.json
-   ```
-
-2. JSON の構文エラーがないか確認する
-   - 不要なカンマがないか
-   - クォートの閉じ忘れがないか
-
-3. Claude Desktop を完全に終了してから再起動する
-   - macOS: アクティビティモニタで Claude プロセスが残っていないか確認
-   - Windows: タスクマネージャーで Claude プロセスが残っていないか確認
-
-### ツールはあるが実行できない
-
-**原因:**
-- jupyter-server が起動していない
-- 環境変数が間違っている
-
-**対処法:**
-1. jupyter-server の起動を確認する
-   ```bash
-   docker ps
-   # jupyter-server が Up 状態か確認
-   ```
-
-2. jupyter-server のログを確認する
-   ```bash
-   cd jupyter-server
-   docker-compose logs
-   ```
-
-3. 設定ファイルの環境変数を確認する
-   - `JUPYTER_SERVER_URL`: http://localhost:8888
-   - `JUPYTER_TOKEN`: docker-compose.yml と一致しているか
+- `.env` の `JUPYTER_TOKEN` と、`claude_desktop_config.json` の `env.JUPYTER_TOKEN` が**完全一致**していることを確認する
+- `.env` の値を変更した場合は `scripts/rebuild.sh jupyter-server` で反映する
+- ブラウザで `http://localhost:8888/?token=<.env の JUPYTER_TOKEN>` にアクセスしてログインできるか確認する
 
 ### コード実行がタイムアウトする
 
-**原因:**
-- カーネルが起動していない
-- ネットワークの問題
+- `docker compose ps` で jupyter-server が `Up (healthy)` であることを確認する
+- `docker compose logs jupyter-server` でエラーが出ていないか確認する
+- jupyter-mcp を手動起動してログを見る場合は `cd jupyter-mcp && npm run dev`
 
-**対処法:**
-1. ブラウザで JupyterLab にアクセスして動作を確認する
-   ```
-   http://localhost:8888/?token=test-token-123
-   ```
+### 画像が認識されない
 
-2. jupyter-mcp のログを確認する（開発モード時）
-   ```bash
-   cd jupyter-mcp
-   npm run dev
-   ```
-
-### 画像が表示されない
-
-**原因:**
-- matplotlib のバックエンド設定
-- 画像リソースの URI が正しくない
-
-**対処法:**
-1. コード実行時に `plt.show()` ではなく `plt.gcf()` を使う
-2. execute_code の結果に `images` 配列が含まれているか確認
-3. `get_image_resource` で画像を明示的に取得する
-
-## 高度な設定
-
-### 複数の MCP サーバーと共存
-
-既存の MCP サーバー設定がある場合の例:
-
-```json
-{
-  "mcpServers": {
-    "existing-server": {
-      "command": "...",
-      "args": ["..."]
-    },
-    "jupyter-mcp": {
-      "command": "node",
-      "args": ["/path/to/jupyter-mcp/dist/index.js"],
-      "env": {
-        "JUPYTER_SERVER_URL": "http://localhost:8888",
-        "JUPYTER_TOKEN": "test-token-123"
-      }
-    }
-  }
-}
-```
-
-### カスタムポート
-
-jupyter-server が別のポートで起動している場合:
-
-```json
-{
-  "mcpServers": {
-    "jupyter-mcp": {
-      "command": "node",
-      "args": ["/path/to/jupyter-mcp/dist/index.js"],
-      "env": {
-        "JUPYTER_SERVER_URL": "http://localhost:9999",
-        "JUPYTER_TOKEN": "your-custom-token"
-      }
-    }
-  }
-}
-```
+- `execute_code` の結果に `images` 配列（`resource_uri` 付き）が含まれているか確認する
+- `matplotlib` のバックエンドが `Agg` 等の非対話モードになっているか確認する
+- 必要に応じて `get_image` ツールで明示的に画像を取得させる
 
 ## 参考リンク
 
-- [MCP Server 開発ガイド](../../.claude/skills/mcp-typescript-server/SKILL.md)
+- [プロジェクト README](../../README.md)
 - [jupyter-mcp 要件定義](../../docs/requirements/jupyter-mcp.md)
-- [プロジェクト全体像](../../docs/overview.md)
+- [MCP Inspector テスト手順書](./inspector-test-guide.md)

--- a/jupyter-mcp/docs/inspector-test-guide.md
+++ b/jupyter-mcp/docs/inspector-test-guide.md
@@ -35,9 +35,11 @@ cd jupyter-mcp && npm run build
 cd jupyter-mcp
 npx @modelcontextprotocol/inspector \
   -e JUPYTER_SERVER_URL=http://localhost:8888 \
-  -e JUPYTER_TOKEN=test-token-123 \
+  -e JUPYTER_TOKEN="$(grep '^JUPYTER_TOKEN=' ../.env | cut -d= -f2-)" \
   node dist/index.js
 ```
+
+`JUPYTER_TOKEN` はプロジェクト直下の `.env` と完全一致させる必要があります（ここではシェル展開で `.env` から読み込んでいます）。
 
 起動後、以下のような出力が表示される：
 


### PR DESCRIPTION
## Summary

- Claude Desktop 接続ドキュメントの古い記述を修正: リテラル `test-token-123` を `.env` 参照に置換、`document-mcp` の必須 `DOCUMENT_SERVER_TOKEN` を追記、README §5 に WSL 向け `wsl.exe` 起動例と設定ファイルパスを追加
- `jupyter-mcp/docs/claude-desktop-setup.md` のセットアップ節を README §5 へのリンクに置換して DRY 化（292 → 約 90 行）。動作確認テストとトラブルシュートのみ残す
- README §4 の欠番を修復（旧 §5 → §4、旧 §6 → §5）。外部参照していた `jupyter-mcp/docs/claude-desktop-setup.md` のアンカーも追従

## 背景

WSL 環境で Claude Desktop から jupyter-server にログインしようとしたところ、ドキュメント記載の `test-token-123` ではなく `.env` の実値が必要だったことで問題が顕在化。調査の結果、ドキュメント側に古いトークンリテラルが散在し、かつ `document-mcp` の `DOCUMENT_SERVER_TOKEN`（未設定だと起動時に throw）が Claude Desktop 設定例から欠落していたため、ユーザー向け手順を `.env` 起点で再整理した。

歴史的記録である `docs/tasks/infrastructure/` 配下のリテラルは当時の計画記録として凍結し、今回は触っていない。

## Test plan

- [ ] README §5 の JSON 例に従って Claude Desktop の設定を行い、jupyter-mcp / document-mcp 両方のツールが表示されること
- [ ] WSL で `wsl.exe` 起動パターンが動作すること
- [ ] `jupyter-mcp/docs/claude-desktop-setup.md` から README §5 への相対リンクが切れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)
