### PR TITLE
docs: README の WSL 設定例に document-mcp を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,14 @@ Claude Desktop の設定ファイル `claude_desktop_config.json` を開きま�
         "JUPYTER_SERVER_URL": "http://localhost:8888",
         "JUPYTER_TOKEN": "<JUPYTER_TOKEN>"
       }
+    },
+    "document-mcp": {
+      "command": "wsl.exe",
+      "args": ["node", "/home/<user>/path/to/document-mcp/dist/index.js"],
+      "env": {
+        "DOCUMENT_SERVER_URL": "http://localhost:3002",
+        "DOCUMENT_SERVER_TOKEN": "<DOCUMENT_SERVER_TOKEN>"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

- README の Claude Desktop 接続設定の WSL 向けセクションに `document-mcp` のエントリを追記
- 非 WSL 向け基本設定には両サーバーの記載があったが、WSL 向けには `jupyter-mcp` のみだったため整合を取る

## Test plan

- [ ] README の WSL セクションで `jupyter-mcp` と `document-mcp` の両方が `wsl.exe` 起動パターンで記載されていることを目視確認
- [ ] JSON としてパース可能であること（構文エラーがないこと）を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
