### PR TITLE
docs: README の Claude Desktop 接続手順を WSL 実環境で動く内容に修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,10 @@ uv が未インストールの場合はスクリプトがインストール手�
 
 ### 3. サービスの起動
 
+初回起動時はデータ環境切り替えスクリプト経由で起動します。PostgreSQL のボリューム初期化・起動待機・CSV データのロードまでを一括で実施します:
+
 ```bash
-docker-compose up -d
+scripts/switch-env.sh sample
 ```
 
 以下のサービスが起動します:
@@ -62,6 +64,8 @@ docker-compose up -d
 | document-server | http://localhost:3002 | カタログ・用語集・ロジックAPI |
 
 JupyterLab にはブラウザで `http://localhost:8888?token=<JUPYTER_TOKEN>` でアクセスできます。
+
+> **`docker-compose up -d` を直接使わない理由**: 素の `docker-compose up -d` はテーブル作成までしか行わず、データロードは走りません（ロードはホスト側 Python から `scripts/lib/common.sh:run_load_data` 経由で実行される設計のため）。初回は必ず `scripts/switch-env.sh sample` を使ってください。`production` 環境に切り替える場合は引数を `production` に変更します。既に起動済みのサービスを停止・再起動するだけなら `docker compose stop` / `docker compose start` で構いません。
 
 ### 4. MCPサーバーのビルド
 
@@ -84,7 +88,9 @@ Claude Desktop の設定ファイル `claude_desktop_config.json` を開きま�
 | OS | パス |
 |----|------|
 | macOS | `~/Library/Application Support/Claude/claude_desktop_config.json` |
-| Windows / WSL | `%APPDATA%\Claude\claude_desktop_config.json` |
+| Windows / WSL | `%LOCALAPPDATA%\Packages\Claude_<PACKAGE_ID>\LocalCache\Roaming\Claude\claude_desktop_config.json` |
+
+> Windows 版 Claude Desktop は MSIX パッケージとして配布されているため、config ファイルは `%APPDATA%\Claude\` ではなく `%LOCALAPPDATA%\Packages\Claude_<PACKAGE_ID>\LocalCache\Roaming\Claude\` 配下に配置されます。`<PACKAGE_ID>` は実環境で `%LOCALAPPDATA%\Packages\` 配下を `Claude_*` で検索して特定してください。迷ったら Claude Desktop メニューの `Settings → Developer → Edit Config` が正しいファイルを開いてくれます。
 
 `mcpServers` に以下のエントリを追加してください:
 
@@ -113,33 +119,56 @@ Claude Desktop の設定ファイル `claude_desktop_config.json` を開きま�
 
 置換ポイント:
 
-- `<absolute-path-to>` — プロジェクトの絶対パス
+- `<absolute-path-to>` — プロジェクトの絶対パス（以下「WSL の場合」節では `<PROJECT_PATH>` と表記）
 - `<JUPYTER_TOKEN>` / `<DOCUMENT_SERVER_TOKEN>` — プロジェクト直下の `.env` の同名変数と**完全一致**させる（不一致だと 401 になる）
 
-**WSL の場合**: Claude Desktop は Windows プロセスのため、Linux パスと Linux 側 `node` を直接指定すると失敗します。`wsl.exe` 経由で起動してください:
+**WSL の場合**: Claude Desktop は Windows プロセスのため、Linux パスと Linux 側 `node` を直接指定すると失敗します。`wsl.exe` 経由で起動しますが、**`node` の絶対パスを指定する必要があります**（理由は下記）。
+
+事前に WSL で以下を実行し、node とプロジェクトの絶対パスを控えておきます:
+
+```bash
+which node                 # → <NODE_PATH>（例: /home/<user>/.nvm/versions/node/v24.14.1/bin/node）
+pwd                        # プロジェクトルートで実行 → <PROJECT_PATH>
+```
+
+控えた値を以下の `<NODE_PATH>` / `<PROJECT_PATH>` に埋め込んでください。**`env` に加えて `WSLENV` を必ず併記する**のがポイントです（理由は下記）:
 
 ```json
 {
   "mcpServers": {
     "jupyter-mcp": {
       "command": "wsl.exe",
-      "args": ["node", "/home/<user>/path/to/jupyter-mcp/dist/index.js"],
+      "args": [
+        "<NODE_PATH>",
+        "<PROJECT_PATH>/jupyter-mcp/dist/index.js"
+      ],
       "env": {
         "JUPYTER_SERVER_URL": "http://localhost:8888",
-        "JUPYTER_TOKEN": "<JUPYTER_TOKEN>"
+        "JUPYTER_TOKEN": "<JUPYTER_TOKEN>",
+        "WSLENV": "JUPYTER_SERVER_URL:JUPYTER_TOKEN"
       }
     },
     "document-mcp": {
       "command": "wsl.exe",
-      "args": ["node", "/home/<user>/path/to/document-mcp/dist/index.js"],
+      "args": [
+        "<NODE_PATH>",
+        "<PROJECT_PATH>/document-mcp/dist/index.js"
+      ],
       "env": {
         "DOCUMENT_SERVER_URL": "http://localhost:3002",
-        "DOCUMENT_SERVER_TOKEN": "<DOCUMENT_SERVER_TOKEN>"
+        "DOCUMENT_SERVER_TOKEN": "<DOCUMENT_SERVER_TOKEN>",
+        "WSLENV": "DOCUMENT_SERVER_URL:DOCUMENT_SERVER_TOKEN"
       }
     }
   }
 }
 ```
+
+> **なぜ `node` の絶対パスが必要か**: nvm でインストールした node は `~/.bashrc` 内で PATH に追加されます。`wsl.exe node ...` は非対話シェルで `.bashrc` を読まず、`wsl.exe bash -lc "node ..."` でもログインシェルは `.bash_profile` / `.profile` しか読まないため、いずれも `node: command not found` になります。確実に動かすには `which node` で得た絶対パスを直接指定してください。
+>
+> **node を更新したら再設定**: nvm で node バージョンを上げるとパスの `v<version>` 部分が変わります。本 config の `<NODE_PATH>` も追従して更新してください。
+>
+> **なぜ `WSLENV` が必要か**: `wsl.exe` は Claude Desktop が `env` で渡した Windows 側環境変数を、既定では Linux 側の子プロセスに転送しません。転送したい変数名をコロン区切りで `WSLENV` に列挙することで初めて Linux 側の node プロセスに渡ります。`WSLENV` を忘れると `DOCUMENT_SERVER_TOKEN が未設定` や jupyter 側の `HTTP 403` といった症状が出ます。
 
 保存後、Claude Desktop を完全終了（macOS: Cmd+Q / Windows: タスクトレイから終了）してから再起動し、ハンマーアイコンに両サーバーのツールが表示されれば成功です。
 


### PR DESCRIPTION
## Summary

- WSL + Windows Claude Desktop 環境で README 手順そのままでは MCP サーバーが接続できない 4 箇所を実環境で動く内容に修正
- `claude_desktop_config.json` のパスを MSIX パッケージ実体に修正
- WSL で `node` を絶対パス指定する必要性と、`wsl.exe` 経由で環境変数を渡すための `WSLENV` の記述を追加
- 初回起動を `scripts/switch-env.sh sample` に変更（`docker-compose up -d` ではデータがロードされないため）

## 背景 / 修正内容

実環境（WSL Ubuntu + nvm + Windows Claude Desktop）で README 通りに設定したところ、以下の順に詰まりました:

1. **config ファイルが見つからない** — 現 README は `%APPDATA%\Claude\...` を案内していますが、公式インストーラは MSIX パッケージなので実体は `%LOCALAPPDATA%\Packages\Claude_<PACKAGE_ID>\LocalCache\Roaming\Claude\` 配下にあります
2. **`node: command not found`** — `wsl.exe node ...` でも `wsl.exe bash -lc "node ..."` でも PATH に node が載りません。nvm が `~/.bashrc` で初期化されるのに対し、非対話シェルは `.bashrc` を、ログインシェルは `.bash_profile`/`.profile` のみを読むためです。`which node` で得た絶対パスを args に直接書く必要があります
3. **`DOCUMENT_SERVER_TOKEN 環境変数が未設定` / jupyter-mcp が HTTP 403** — `wsl.exe` は Windows 側の環境変数を既定では Linux 側に転送しません。`WSLENV` にコロン区切りで変数名を列挙する必要があります
4. **`execute_sql` でデータが空** — `docker-compose up -d` はテーブル作成までしか行わず、データロードは `scripts/lib/common.sh:run_load_data` 経由（ホスト側 Python から `load-data.py` を呼ぶ設計）です。初回起動を `scripts/switch-env.sh sample` に寄せることで一括解決

いずれも WSL + nvm 構成なら全員が踏むはずで、README に明記しておく価値があります。パスはユーザー環境に応じて変わるため `<NODE_PATH>` / `<PROJECT_PATH>` / `<PACKAGE_ID>` 等の変数で表記しています。

## Test plan

- [x] 実環境（WSL Ubuntu + nvm v24.14.1 + Windows Claude Desktop MSIX 版）で本 PR の手順を上から順にたどり、Claude Desktop のコネクタに `jupyter-mcp` / `document-mcp` の両ツール群が表示されることを確認
- [x] Claude Desktop から `execute_sql` 経由で `customer_master` / `product_master` / `purchase_history` のデータが実際に取得できることを確認
- [ ] 別の WSL ユーザー環境でも同手順が通ることのレビュー（可能なら）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
