### PR TITLE
chore: .mainignore に既存の漏れを追加

### DIFF
--- a/.mainignore
+++ b/.mainignore
@@ -7,6 +7,8 @@
 .claude/commands/custom-auto-audit-docs.md
 .claude/commands/custom-auto-dev.md
 .claude/commands/custom-change-requirement.md
+.claude/commands/custom-cleanup-branches.md
+.claude/commands/custom-commit.md
 .claude/commands/custom-complete-task.md
 .claude/commands/custom-fix-bug.md
 .claude/commands/custom-plan-task.md
@@ -16,6 +18,7 @@
 .claude/commands/custom-resolve-issues.md
 .claude/commands/custom-start-fix.md
 .claude/commands/custom-start-task.md
+.claude/commands/custom-status.md
 .claude/commands/custom-update-plan.md
 
 # Claude skills (dev only)
@@ -26,6 +29,7 @@
 # Claude agents (dev only)
 .claude/agents/code-reviewer.md
 .claude/agents/impact-analyzer.md
+.claude/agents/requirements-researcher.md
 .claude/agents/requirements-verifier.md
 
 # Claude rules (dev only)
@@ -49,8 +53,10 @@ docs/issues/
 docs/PLAN.md
 
 # Dev scripts
-scripts/manage-known-failures.sh
+scripts/cleanup-merged-branches.sh
 scripts/create-test-issue.sh
+scripts/manage-known-failures.sh
+scripts/promote-to-main.sh
 
 # Dev testing
 tests/known-failures.json


### PR DESCRIPTION
## Summary

- `.mainignore` に過去リリースで main に流入してしまった dev-only ファイル 6 件を追記
- 次回 `scripts/promote-to-main.sh` 実行時に main 側から自動削除される
- `custom-ask` / `custom-sync-db` / `codebase-explorer` および実装系 skills は、プロジェクト理解・ビルド・テストに必要なため main に残す方針

### 追加内容

- `.claude/commands/custom-cleanup-branches.md`
- `.claude/commands/custom-commit.md`
- `.claude/commands/custom-status.md`
- `.claude/agents/requirements-researcher.md`
- `scripts/cleanup-merged-branches.sh`
- `scripts/promote-to-main.sh`

## Test plan

- [x] `.mainignore` の内容を目視確認
- [ ] dev マージ後、`scripts/promote-to-main.sh --dry-run` で除外対象に 6 件が追加されていることを確認
- [ ] プロンプトテンプレート修正後、本番の promote を実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)
