### PR TITLE
chore: CI に npm audit の informational ジョブを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,28 @@ jobs:
         run: echo "Skipped — docs-only change"
 
   # ──────────────────────────────────────────────
+  # npm audit（参考 — 依存の新規公表脆弱性を可視化、失敗しても CI をブロックしない。
+  # 脆弱性 DB は日々更新されるため、コード無変更でも赤になりうる → informational）
+  # ──────────────────────────────────────────────
+  npm-audit:
+    name: npm audit (informational)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+
+      # npm audit は package-lock.json のみで動作するため npm ci は不要
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Audit root workspaces (high 以上)
+        run: npm audit --audit-level=high
+
+      - name: Audit jupyterlab-ai-sync (high 以上)
+        run: npm --prefix jupyterlab-ai-sync audit --audit-level=high
+
+  # ──────────────────────────────────────────────
   # パフォーマンステスト（参考 — 失敗しても CI をブロックしない）
   # ──────────────────────────────────────────────
   performance-test:


### PR DESCRIPTION
## Summary
- CI に `npm audit (informational)` ジョブを追加（Performance test と同じ continue-on-error 方式）
- ルート workspaces と jupyterlab-ai-sync（独立 lock）の両方を `--audit-level=high` で監査
- 依存に high 以上の脆弱性が新規公表されたとき、PR の CI 画面で自動的に可視化される（マージはブロックしない）
- `npm audit` は package-lock.json のみで動作するため `npm ci` 不要の軽量ジョブ（数十秒）

## Test plan
- ローカルで YAML 構文チェック（yaml.safe_load）OK
- ローカルで両 audit コマンドを実行し `found 0 vulnerabilities` を確認
- この PR 自身の CI で新ジョブ `npm audit (informational)` が pass することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
