### PR TITLE
chore: タスク 13.1 npm 依存パッケージの脆弱性修正

### DIFF
--- a/docs/plan/04-infrastructure.md
+++ b/docs/plan/04-infrastructure.md
@@ -15,3 +15,13 @@
 | 11.1 | ADR・横断不変条件・タスク設計ルールの整備 | [x] | 計画作成時に異常系AC・不変条件・ADR要否のチェックが要求され、/custom-debt-review で横断監査が実行できる | docs/adr/（テンプレ+0001）、docs/design/invariants.md（I1〜I8）、task-design.md チェックリスト拡張、change-requirement に異常系レンズ追加 |
 | 11.2 | CI 適応度関数（構造予算の機械検知） | [ ] | ファイルサイズ予算超過・async 内ブロッキング I/O（ruff ASYNC ルール）・コピペ検出が CI で検知される | 既存違反（handlers.py 1,515行等）の解消とセットで有効化。リファクタ Phase と同時に計画する |
 
+---
+
+## Phase 13: npm 依存パッケージの脆弱性修正
+
+npm audit で検出された high/moderate 脆弱性の解消。CI の npm audit (informational) ジョブを pass させ、PR の `mergeStateStatus` が `UNSTABLE` にならないようにする。
+
+| # | タスク | ステータス | E2Eテスト | 備考 |
+|---|--------|-----------|-----------|------|
+| 13.1 | npm 依存パッケージの脆弱性修正 | [ ] | `npm audit --audit-level=high` が exit 0 で終了する。CI の npm audit (informational) ジョブが pass する | `fast-uri` 3.0.0-3.1.3 (high: host confusion via backslash)、`@hono/node-server` <2.0.5 (moderate: path traversal on Windows, `@modelcontextprotocol/sdk` 経由の間接依存) |
+

--- a/docs/plan/04-infrastructure.md
+++ b/docs/plan/04-infrastructure.md
@@ -2,7 +2,7 @@
 
 テスト、ビルド、データロード、Formatter に関する Phase。
 
-完了した Phase 1〜10, 12 は [archive/04-infrastructure.md](archive/04-infrastructure.md) を参照。
+完了した Phase 1〜10, 12〜13 は [archive/04-infrastructure.md](archive/04-infrastructure.md) を参照。
 
 ---
 
@@ -14,14 +14,4 @@
 |---|--------|-----------|-----------|------|
 | 11.1 | ADR・横断不変条件・タスク設計ルールの整備 | [x] | 計画作成時に異常系AC・不変条件・ADR要否のチェックが要求され、/custom-debt-review で横断監査が実行できる | docs/adr/（テンプレ+0001）、docs/design/invariants.md（I1〜I8）、task-design.md チェックリスト拡張、change-requirement に異常系レンズ追加 |
 | 11.2 | CI 適応度関数（構造予算の機械検知） | [ ] | ファイルサイズ予算超過・async 内ブロッキング I/O（ruff ASYNC ルール）・コピペ検出が CI で検知される | 既存違反（handlers.py 1,515行等）の解消とセットで有効化。リファクタ Phase と同時に計画する |
-
----
-
-## Phase 13: npm 依存パッケージの脆弱性修正
-
-npm audit で検出された high/moderate 脆弱性の解消。CI の npm audit (informational) ジョブを pass させ、PR の `mergeStateStatus` が `UNSTABLE` にならないようにする。
-
-| # | タスク | ステータス | E2Eテスト | 備考 |
-|---|--------|-----------|-----------|------|
-| 13.1 | npm 依存パッケージの脆弱性修正 | [ ] | `npm audit --audit-level=high` が exit 0 で終了する。CI の npm audit (informational) ジョブが pass する | `fast-uri` 3.0.0-3.1.3 (high: host confusion via backslash)、`@hono/node-server` <2.0.5 (moderate: path traversal on Windows, `@modelcontextprotocol/sdk` 経由の間接依存) |
 

--- a/docs/plan/archive/04-infrastructure.md
+++ b/docs/plan/archive/04-infrastructure.md
@@ -172,3 +172,13 @@ AIエージェントが読み込むコンテキストの削減と、ドキュメ
 | 12.3 | docker-compose 表記の v2 統一 | [x] | `grep -r "docker-compose"` がプロジェクト内でヒットしない（docker compose v2 表記に統一） | bootstrap.sh、CLAUDE.md 類 |
 | 12.4 | Node.js バージョンの明示固定 | [x] | .nvmrc が存在し、package.json に engines フィールドがあり、CI と一致する | 全 package.json + .nvmrc |
 | 12.5 | jupyterlab-ai-sync ビルドの決定的化 | [x] | Dockerfile と CI で `npm ci` が使用され、`npm install` が使われていない | npm install → npm ci |
+
+---
+
+## Phase 13: npm 依存パッケージの脆弱性修正
+
+npm audit で検出された high/moderate 脆弱性の解消。CI の npm audit (informational) ジョブを pass させ、PR の `mergeStateStatus` が `UNSTABLE` にならないようにする。
+
+| # | タスク | ステータス | E2Eテスト | 備考 |
+|---|--------|-----------|-----------|------|
+| 13.1 | npm 依存パッケージの脆弱性修正 | [x] | `npm audit --audit-level=high` が exit 0 で終了する。CI の npm audit (informational) ジョブが pass する | `fast-uri` 3.0.0-3.1.3 (high: host confusion via backslash)、`@hono/node-server` <2.0.5 (moderate: path traversal on Windows, `@modelcontextprotocol/sdk` 経由の間接依存) |

--- a/docs/tasks/archive/infrastructure/13.1-npm-audit-fix.md
+++ b/docs/tasks/archive/infrastructure/13.1-npm-audit-fix.md
@@ -1,0 +1,119 @@
+# タスク詳細: 13.1 npm 依存パッケージの脆弱性修正
+
+## 概要
+
+npm audit で検出された high 以上の脆弱性を修正し、CI の npm audit (informational) ジョブを pass させる。
+
+対象脆弱性:
+
+| パッケージ | 深刻度 | 脆弱性 | 影響範囲 |
+|-----------|--------|--------|---------|
+| `fast-uri` 3.0.0-3.1.3 | high | host confusion via backslash ([GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx)) | root workspace + jupyterlab-ai-sync |
+| `brace-expansion` <1.1.16 | high | DoS via exponential-time expansion ([GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp)) | jupyterlab-ai-sync のみ |
+| `@hono/node-server` <2.0.5 | moderate | path traversal on Windows ([GHSA-frvp-7c67-39w9](https://github.com/advisories/GHSA-frvp-7c67-39w9)) | root workspace（`@modelcontextprotocol/sdk` 経由） |
+| `dompurify` <=3.4.11 | low | `CUSTOM_ELEMENT_HANDLING` bypass ([GHSA-c2j3-45gr-mqc4](https://github.com/advisories/GHSA-c2j3-45gr-mqc4)) | jupyterlab-ai-sync のみ |
+
+## 関連ドキュメント
+
+- タスク定義: `docs/plan/04-infrastructure.md` Phase 13
+- 不変条件: `docs/design/invariants.md` I7（ビルドの入力はバージョン固定する）
+
+## 調査したファイル
+
+- `package.json`: ワークスペース構成（`packages/mcp-shared`, `jupyter-mcp`, `document-mcp`, `tests/e2e`）
+- `package-lock.json`: `fast-uri@3.1.3`, `@hono/node-server@1.19.14`, `ajv@8.20.0` のバージョン確認
+- `packages/mcp-shared/package.json`: `@modelcontextprotocol/sdk@^1.29.0`
+- `jupyter-mcp/package.json`: `@modelcontextprotocol/sdk@^1.29.0`
+- `document-mcp/package.json`: `@modelcontextprotocol/sdk@^1.29.0`
+- `jupyterlab-ai-sync/package.json`, `jupyterlab-ai-sync/package-lock.json`: 別系統のロックファイル、`fast-uri@3.1.3`, `brace-expansion@1.1.13`, `dompurify@3.4.11`
+- `.github/workflows/ci.yml` L328-348: npm audit ジョブ（`continue-on-error: true`, `--audit-level=high`）
+- `jupyter-mcp/src/`, `document-mcp/src/`, `packages/mcp-shared/src/`: `serve-static` / `@hono/node-server` の直接利用なし
+
+## 検討した代替案
+
+| 案 | 概要 | 利点 | 欠点 |
+|----|------|------|------|
+| A（採用） | `npm audit fix` で high 脆弱性を修正。moderate の `@hono/node-server` は対応不要 | 最小変更。semver 範囲内の安全なパッチ。SDK との互換性リスクなし | `@hono/node-server` moderate は残る（CI では `--audit-level=high` のため検知されない） |
+| B | 案 A + `overrides` で `@hono/node-server` >= 2.0.5 を強制 | 全脆弱性を解消 | `@hono/node-server` 1.x → 2.x はメジャーバージョン変更。SDK 内部の互換性が不明。実影響なし（Windows 限定 serve-static、プロジェクト未使用）のため過剰対応 |
+
+採用理由: CI の `--audit-level=high` は moderate を検知しない。`@hono/node-server` は Windows 限定・`serve-static` 限定の脆弱性で、本プロジェクトでは直接使用していない（SDK の間接依存のみ、Docker は Linux）。SDK 上流が `@hono/node-server` 2.x に更新すれば `^1.29.0` の範囲で自動的に解消される。
+
+ADR 要否: 不要。パッチバージョンのセキュリティ更新であり、アーキテクチャ上の判断を伴わない。
+
+## 参考にする既存実装
+
+該当なし（依存パッケージの更新のみ）。
+
+## 異常系・不変条件
+
+- 該当する異常系: `npm audit fix` がパッケージの API 互換性を壊す可能性。`npm audit fix --dry-run` で更新内容が semver 範囲内のパッチであることを事前確認済み
+- 関係する不変条件: I7（ビルドの入力はバージョン固定する）。lock ファイルの更新は意図的な PR で行う — 本タスクがそれに該当する
+
+## 実装計画
+
+### 作成・変更するファイル
+
+| ファイル | 内容 |
+|----------|------|
+| `package-lock.json` | `fast-uri` 3.1.3 → 3.1.4 |
+| `jupyterlab-ai-sync/package-lock.json` | `fast-uri` 3.1.3 → 3.1.4, `brace-expansion` 1.1.13 → 1.1.16, `dompurify` 3.4.11 → 3.4.12 |
+
+### 参照ファイル（実装時に Read するファイル）
+
+| ファイル | 参照理由・注目箇所 |
+|----------|-------------------|
+| `package.json` | ワークスペース構成の確認 |
+| `.github/workflows/ci.yml` L328-348 | npm audit ジョブの設定確認 |
+
+### 実装手順
+
+1. root ワークスペースの `npm audit fix` を実行
+   - 検証: `npm audit --audit-level=high` が exit 0
+2. jupyterlab-ai-sync の `npm audit fix` を実行（`npm --prefix jupyterlab-ai-sync audit fix`）
+   - 検証: `npm --prefix jupyterlab-ai-sync audit --audit-level=high` が exit 0
+3. 全コンポーネントのテスト実行（`scripts/test.sh`）。jupyterlab-ai-sync のビルドも `scripts/test.sh` 内で `uv run` 経由で実行される
+   - 検証: 全テストが pass
+
+### 技術的な考慮事項
+
+- `fast-uri` 3.1.3 → 3.1.4 は `^3.0.1` の semver 範囲内パッチ更新。API 互換性の懸念なし
+- `brace-expansion` 1.1.13 → 1.1.16 は `^1.1.13` の semver 範囲内パッチ更新
+- `dompurify` 3.4.11 → 3.4.12 は `^3.4.11` の semver 範囲内パッチ更新
+- `package-lock.json` の差分には optional dependencies（lightningcss, @rolldown/binding 等のプラットフォーム固有パッケージ）が含まれる場合がある。これは npm のロックファイル再生成に伴う正常な挙動
+
+## リスクと検知方法
+
+- パッケージ更新による既存テストの回帰・jupyterlab-ai-sync のビルド破損: `scripts/test.sh` の全テスト実行で検知（jupyterlab-ai-sync のビルドも含む）
+
+## 完了条件
+
+- [ ] `npm audit --audit-level=high` が exit 0（root ワークスペース）
+- [ ] `npm --prefix jupyterlab-ai-sync audit --audit-level=high` が exit 0
+- [ ] `scripts/test.sh` の全テストが pass（jupyterlab-ai-sync のビルド検証を含む）
+- [ ] CI の npm audit (informational) ジョブの両ステップ（root + jupyterlab-ai-sync）が pass
+
+## テスト計画
+
+### 既存テストの被覆状況
+
+本タスクは新規テストの作成を伴わない。既存テストスイートで回帰がないことを確認する。
+
+- `jupyter-mcp/tests/`: MCP サーバーのユニットテスト（`@modelcontextprotocol/sdk` 経由で `fast-uri` を間接利用）
+- `document-mcp/tests/`: MCP サーバーのユニットテスト（同上）
+- `jupyterlab-ai-sync/tests/unit/`: フロントエンド拡張のユニットテスト（`path-utils.test.ts`, `notebook-finder.test.ts`, `event-validation.test.ts`, `lock-manager.test.ts`）
+
+### 新規テスト
+
+なし。依存パッケージのパッチ更新のため、既存テストの全 pass で十分。
+
+### テスト参照ポインタ（テスト準備フェーズはこの範囲のみ Read する）
+
+該当なし（新規テスト作成なし）。
+
+---
+
+## レビューステータス
+
+- [x] 計画レビュー完了
+- [ ] 実装完了
+- [ ] テスト完了

--- a/jupyterlab-ai-sync/package-lock.json
+++ b/jupyterlab-ai-sync/package-lock.json
@@ -2956,9 +2956,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4005,9 +4005,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
-      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -4347,9 +4347,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "ai-data-analysis-platform",
       "workspaces": [
         "packages/mcp-shared",
         "jupyter-mcp",
@@ -1224,9 +1225,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- `npm audit fix` で high 以上の脆弱性を解消
  - `fast-uri` 3.1.3 → 3.1.4 (high: host confusion via backslash, GHSA-v2hh-gcrm-f6hx)
  - `brace-expansion` 1.1.13 → 1.1.16 (high: DoS via exponential-time expansion, GHSA-3jxr-9vmj-r5cp)
  - `dompurify` 3.4.11 → 3.4.12 (low: CUSTOM_ELEMENT_HANDLING bypass, GHSA-c2j3-45gr-mqc4)
- すべて semver 範囲内のパッチ更新。`package.json` の変更なし
- `@hono/node-server` の moderate 脆弱性は SDK メジャーバージョン変更が必要なためスコープ外（Windows 限定・serve-static 限定で実影響なし）

## Test plan

- [x] `npm audit --audit-level=high` が exit 0（root ワークスペース）
- [x] `npm --prefix jupyterlab-ai-sync audit --audit-level=high` が exit 0
- [x] `scripts/test.sh --quiet` の全テストが pass（lint + 型チェック + 全テスト）
- [ ] CI の npm audit (informational) ジョブの両ステップが pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
