### PR TITLE
refactor: document-server のエラーレスポンス機構を exception_handler へ統一（9.3）

### DIFF
--- a/docs/plan/02-document.md
+++ b/docs/plan/02-document.md
@@ -2,7 +2,7 @@
 
 カタログ、用語集、ロジック、コンテキストエンジニアリングに関する Phase。
 
-完了した Phase 1〜7 は [archive/02-document.md](archive/02-document.md) を参照。
+完了した Phase 1〜7・9 は [archive/02-document.md](archive/02-document.md) を参照。
 
 ---
 
@@ -13,15 +13,3 @@
 | # | タスク | ステータス | E2Eテスト | 備考 |
 |---|--------|-----------|-----------|------|
 | 8.1 | document-mcp: 全ツール呼び出しのログ出力 | [ ] | ツール呼び出しの開始・完了・エラーがログに出力される | logger.ts は存在するがツール実行層で未使用 |
-
----
-
-## Phase 9: document-server 改善
-
-`tmp/refactor-notes.md` §3 で指摘された document-server の負債解消（大規模リファクタリング S7）。低優先の §3-5（用語検索の線形走査・detail ディレクトリ欠損の検知遅れ）と §3-6（新ルーター追加時の protected_router 登録忘れ）はスコープ外とする。9.1 と 9.3 は同じ `admin.py` を触るため 9.1 → 9.2 → 9.3 の順に直列で進める。各タスクの詳細計画は着手時に `/custom-plan-task` で個別に作成する。
-
-| # | タスク | ステータス | E2Eテスト | 備考 |
-|---|--------|-----------|-----------|------|
-| 9.1 | /admin/reload の copy-on-write アトミック化 | [x] | reload が途中失敗（YAML 構文エラー等）しても既存 API は旧カタログを返し続け、成功時のみ新カタログへ切り替わる（不正入力・並行の異常系） | 新ストアを構築してから `app.state` の参照をアトミックに差し替える。並行 reload はロックで直列化（§3-1、invariants I6） |
-| 9.2 | YAML エラー処理の統一と /health 可視化 | [x] | 不正な YAML ファイル（構文エラー・必須キー欠損）の reload/起動時の扱いが統一され、スキップ件数が /health で確認できる（不正入力） | 構文エラー=全体失敗 / id_field 欠損=警告スキップ / その他必須キー欠損=全体失敗の非対称を解消（§3-2） |
-| 9.3 | エラーレスポンス機構の統一 | [→] | エラー時も `{"error": {...}}` 形式が維持されたまま `dict \| JSONResponse` 戻り値が解消され、OpenAPI にレスポンス型が復活する。Pydantic ValidationError が INTERNAL_ERROR ではなくデータ不正として分類される（不正入力） | exception_handler ベースへ統一（`admin.py` / `logic.py` の `response_model=None` 解消、§3-3/3-4） |

--- a/docs/plan/02-document.md
+++ b/docs/plan/02-document.md
@@ -24,4 +24,4 @@
 |---|--------|-----------|-----------|------|
 | 9.1 | /admin/reload の copy-on-write アトミック化 | [x] | reload が途中失敗（YAML 構文エラー等）しても既存 API は旧カタログを返し続け、成功時のみ新カタログへ切り替わる（不正入力・並行の異常系） | 新ストアを構築してから `app.state` の参照をアトミックに差し替える。並行 reload はロックで直列化（§3-1、invariants I6） |
 | 9.2 | YAML エラー処理の統一と /health 可視化 | [x] | 不正な YAML ファイル（構文エラー・必須キー欠損）の reload/起動時の扱いが統一され、スキップ件数が /health で確認できる（不正入力） | 構文エラー=全体失敗 / id_field 欠損=警告スキップ / その他必須キー欠損=全体失敗の非対称を解消（§3-2） |
-| 9.3 | エラーレスポンス機構の統一 | [ ] | エラー時も `{"error": {...}}` 形式が維持されたまま `dict \| JSONResponse` 戻り値が解消され、OpenAPI にレスポンス型が復活する。Pydantic ValidationError が INTERNAL_ERROR ではなくデータ不正として分類される（不正入力） | exception_handler ベースへ統一（`admin.py` / `logic.py` の `response_model=None` 解消、§3-3/3-4） |
+| 9.3 | エラーレスポンス機構の統一 | [→] | エラー時も `{"error": {...}}` 形式が維持されたまま `dict \| JSONResponse` 戻り値が解消され、OpenAPI にレスポンス型が復活する。Pydantic ValidationError が INTERNAL_ERROR ではなくデータ不正として分類される（不正入力） | exception_handler ベースへ統一（`admin.py` / `logic.py` の `response_model=None` 解消、§3-3/3-4） |

--- a/docs/plan/archive/02-document.md
+++ b/docs/plan/archive/02-document.md
@@ -87,3 +87,15 @@ document-server の REST API に認証を追加する。現在は信頼された
 | 7.1 | document-server: Bearer トークン認証の実装 | [x] | 認証トークンなしのリクエストが 401 で拒否され、正しいトークン付きリクエストが成功する | jupyter-server の既存トークン認証を参考に実装 |
 | 7.2 | document-mcp: 認証トークン付与 | [x] | document-mcp から document-server への全リクエストに Authorization ヘッダーが付与される | 環境変数でトークンを設定 |
 | 7.3 | REST API 認証の結合テスト | [x] | document-mcp 経由でカタログ・用語集・ロジックの取得が認証付きで正常動作する | 認証なしアクセスの拒否も確認 |
+
+---
+
+## Phase 9: document-server 改善
+
+`tmp/refactor-notes.md` §3 で指摘された document-server の負債解消（大規模リファクタリング S7）。低優先の §3-5（用語検索の線形走査・detail ディレクトリ欠損の検知遅れ）と §3-6（新ルーター追加時の protected_router 登録忘れ）はスコープ外とする。9.1 と 9.3 は同じ `admin.py` を触るため 9.1 → 9.2 → 9.3 の順に直列で進める。各タスクの詳細計画は着手時に `/custom-plan-task` で個別に作成する。
+
+| # | タスク | ステータス | E2Eテスト | 備考 |
+|---|--------|-----------|-----------|------|
+| 9.1 | /admin/reload の copy-on-write アトミック化 | [x] | reload が途中失敗（YAML 構文エラー等）しても既存 API は旧カタログを返し続け、成功時のみ新カタログへ切り替わる（不正入力・並行の異常系） | 新ストアを構築してから `app.state` の参照をアトミックに差し替える。並行 reload はロックで直列化（§3-1、invariants I6） |
+| 9.2 | YAML エラー処理の統一と /health 可視化 | [x] | 不正な YAML ファイル（構文エラー・必須キー欠損）の reload/起動時の扱いが統一され、スキップ件数が /health で確認できる（不正入力） | 構文エラー=全体失敗 / id_field 欠損=警告スキップ / その他必須キー欠損=全体失敗の非対称を解消（§3-2） |
+| 9.3 | エラーレスポンス機構の統一 | [x] | エラー時も `{"error": {...}}` 形式が維持されたまま `dict \| JSONResponse` 戻り値が解消され、OpenAPI にレスポンス型が復活する。Pydantic ValidationError が INTERNAL_ERROR ではなくデータ不正として分類される（不正入力） | exception_handler ベースへ統一（`admin.py` / `logic.py` の `response_model=None` 解消、§3-3/3-4） |

--- a/docs/tasks/archive/document/9.3-error-response-unification.md
+++ b/docs/tasks/archive/document/9.3-error-response-unification.md
@@ -126,12 +126,12 @@ ADR 要否: 不要。エラーレスポンス形式 `{"error": {...}}` は既存
 
 ## 完了条件
 
-- [ ] `grep -n "response_model=None" document-server/src/routers/admin.py document-server/src/routers/logic.py` → 0 件
-- [ ] `grep -n "dict | JSONResponse" document-server/src/routers/admin.py document-server/src/routers/logic.py` → 0 件
-- [ ] `grep -n "from.*responses.*import.*error_response" document-server/src/routers/admin.py document-server/src/routers/logic.py` → 0 件（ルーターが error_response を直接呼ばない）
-- [ ] `bash scripts/test.sh --quiet --test --no-lint document-server -- tests/test_error_handling.py` → PASS（exception_handler の統一形式テスト）
-- [ ] `bash scripts/test.sh --quiet document-server` → 全テスト PASS、lint / mypy PASS
-- [ ] 不正入力時（空リスト等）のレスポンスが `{"error": {"code": "VALIDATION_ERROR", "message": ...}}` 形式であること（`test_error_handling.py` で検証）
+- [x] `grep -n "response_model=None" document-server/src/routers/admin.py document-server/src/routers/logic.py` → 0 件
+- [x] `grep -n "dict | JSONResponse" document-server/src/routers/admin.py document-server/src/routers/logic.py` → 0 件
+- [x] `grep -n "from.*responses.*import.*error_response" document-server/src/routers/admin.py document-server/src/routers/logic.py` → 0 件（ルーターが error_response を直接呼ばない）
+- [x] `bash scripts/test.sh --quiet --test --no-lint document-server -- tests/test_error_handling.py` → PASS（exception_handler の統一形式テスト）
+- [x] `bash scripts/test.sh --quiet document-server` → 全テスト PASS、lint / mypy PASS
+- [x] 不正入力時（空リスト等）のレスポンスが `{"error": {"code": "VALIDATION_ERROR", "message": ...}}` 形式であること（`test_error_handling.py` で検証）
 
 ## テスト計画
 
@@ -164,5 +164,5 @@ ADR 要否: 不要。エラーレスポンス形式 `{"error": {...}}` は既存
 ## レビューステータス
 
 - [x] 計画レビュー完了
-- [ ] 実装完了
-- [ ] テスト完了
+- [x] 実装完了
+- [x] テスト完了

--- a/docs/tasks/document/9.3-error-response-unification.md
+++ b/docs/tasks/document/9.3-error-response-unification.md
@@ -1,0 +1,168 @@
+# タスク詳細: 9.3 エラーレスポンス機構の統一
+
+## 概要
+
+document-server の admin.py / logic.py で使われている `dict | JSONResponse` 戻り値パターン（try/except 内で `error_response()` を return）を、exception_handler ベースに統一する。これにより `response_model=None` を解消して OpenAPI にレスポンス型を復活させ、Pydantic ValidationError のエラー分類も適正化する。
+
+## 関連ドキュメント
+
+- 要件定義: `docs/requirements/document-server.md`（エラーレスポンスの具体的形式はコードが SSoT）
+- API仕様: `docs/design/api-contracts.md`（エラー形式 `{"error": {"code": ..., "message": ...}}`、`{"data": ...}` の共通契約）
+- セキュリティ: `.claude/rules/security.md` §6（本番環境でのエラー詳細非公開）
+
+## 調査したファイル
+
+- `document-server/src/routers/admin.py`: `response_model=None` + `dict | JSONResponse` 戻り値。try/except 内で `error_response()` を return するパターン。`except (ValueError, OSError)` → 400、`except Exception` → 500
+- `document-server/src/routers/logic.py`: `/meta` は `response_model=None` だがエラーパスなし。`/code/{logic_name}` は `dict | JSONResponse` 戻り値で `LogicCodeNotFoundError` / `None` を個別に error_response で返却
+- `document-server/src/main.py`: exception_handler の登録なし。auth の HTTPException は FastAPI 標準 `{"detail": ...}` 形式で処理される
+- `document-server/src/responses.py`: `error_response()` が JSONResponse を直接構築。`index_response()` / `detail_response()` は dict 返却
+- `document-server/src/models.py`: リクエストモデル・データモデル定義あり。レスポンスラッパーモデルは未定義
+- `document-server/src/auth.py`: HTTPException(status_code=401) を raise。detail は文字列
+- `document-server/src/catalog_loader.py`: `LogicCodeNotFoundError(Exception)` 定義あり（L40）。pydantic ValidationError は ValueError サブクラスのため、admin.py の `except (ValueError, OSError)` でキャッチされる
+- `document-server/src/routers/tables.py:19`, `terms.py:27`: `response_model=None` あるが `dict | JSONResponse` ではない（本タスクのスコープ外）
+
+## 検討した代替案
+
+| 案 | 概要 | 利点 | 欠点 |
+|----|------|------|------|
+| A（採用） | カスタム例外クラス + `@app.exception_handler` | ハンドラから `JSONResponse` 返却が消え型安全。例外クラスが型付きでテストしやすい。auth.py の HTTPException と競合しない | 新ファイル `exceptions.py` が増える |
+| B | HTTPException に構造化 detail を載せ、HTTPException ハンドラをオーバーライド | 新クラス不要 | auth.py が string detail で HTTPException を使っており、ハンドラ内で string/dict を場合分けする必要がある。detail は Any 型で型安全性なし |
+
+採用理由: auth.py の HTTPException 使用と衝突せず、例外クラスの型フィールド（status_code, code, message）で IDE 補完・テスト時の型チェックが効く。`.claude/rules/security.md` §6 の exception_handler パターンとも一致。
+
+ADR 要否: 不要。エラーレスポンス形式 `{"error": {...}}` は既存契約を維持し、実装手段の変更のみ。コンポーネント間契約の変更なし。
+
+## 参考にする既存実装
+
+- コピー元: なし（exception_handler は document-server 内に既存実装がない。`.claude/rules/security.md` §6 のパターンを参考にする）
+- `LogicCodeNotFoundError`（`catalog_loader.py:40`）は既存の例外クラスで、新 exceptions.py に移動する（同種の例外が 2 箇所目。rule of three には未到達）
+
+## 異常系・不変条件
+
+- 該当する異常系（不正入力）: Pydantic ValidationError が発生した場合でも `{"error": {"code": "VALIDATION_ERROR", ...}}` 形式で返却され、500 INTERNAL_ERROR にならない。テスト `test_validation_error_returns_unified_format` で検証
+- 関係する不変条件: I4（プロセス境界のランタイム検証）— RequestValidationError のエラーレスポンスが統一形式になることで、MCP サーバー側のエラー判別が安定する
+
+## 実装計画
+
+### 作成・変更するファイル
+
+| ファイル | 内容 |
+|----------|------|
+| `document-server/src/exceptions.py`（新規） | `AppError` 基底クラス、`CatalogLoadError`、`ResourceNotFoundError` |
+| `document-server/src/main.py` | exception_handler 4 種の登録（AppError, RequestValidationError, pydantic.ValidationError, Exception） |
+| `document-server/src/models.py` | レスポンスラッパーモデル追加（`ErrorDetail`, `ReloadData`, `ReloadResponse`, `LogicCodeData`, `LogicCodeResponse`） |
+| `document-server/src/routers/admin.py` | try/except の return → raise 変換、`response_model=ReloadResponse` 復活、`dict | JSONResponse` 戻り値型の解消 |
+| `document-server/src/routers/logic.py` | `/meta` の `response_model=None` 削除、`/code` の return → raise 変換 + `response_model=LogicCodeResponse` 復活 |
+| `document-server/tests/test_error_handling.py`（新規） | exception_handler のユニットテスト（RequestValidationError 形式、pydantic.ValidationError 分類、generic Exception 形式） |
+| `document-server/tests/test_admin_api.py` | 既存エラーテストのレスポンス形式検証を強化 |
+| `document-server/tests/test_logic_api.py` | 422 レスポンスの形式検証を追加 |
+
+### 参照ファイル（実装時に Read するファイル）
+
+| ファイル | 参照理由・注目箇所 |
+|----------|-------------------|
+| `document-server/src/responses.py:1-22` | error_response / index_response / detail_response のシグネチャ。exception_handler で error_response を再利用するか判断 |
+| `document-server/src/catalog_loader.py:40` | `LogicCodeNotFoundError` の現在の定義位置。exceptions.py への移動時に参照 |
+| `document-server/src/auth.py:1-60` | HTTPException の使い方。exception_handler が auth の挙動を壊さないことの確認 |
+| `document-server/tests/test_admin_api.py:54-101` | `test_reload_failure_keeps_old_catalog` — エラーレスポンス形式の既存アサーション |
+| `document-server/tests/test_logic_api.py:92-94` | `test_get_logic_meta_empty_names` — 422 ステータスの既存テスト |
+| `document-server/tests/test_logic_api.py:118-149` | `/code` の 404 エラーテスト — error code の既存アサーション |
+| `document-server/tests/conftest.py:255-306` | `sample_data_dir` / `client` fixture の構成 |
+
+※実装・テスト準備フェーズはこの表と「作成・変更するファイル」「テスト参照ポインタ」の範囲でのみ作業する（範囲外の Glob/Grep 探索は禁止）。情報が不足していたら探索せず、不足内容を報告して終了する。
+
+### 実装手順
+
+1. `document-server/src/exceptions.py` を新規作成。`AppError(Exception)` に `status_code`, `code`, `message` フィールド、サブクラス `CatalogLoadError`（400, CATALOG_LOAD_ERROR）、`ResourceNotFoundError`（404, code は引数）を定義。`LogicCodeNotFoundError` は `catalog_loader.py` から移動せず残す（呼び出し元が catalog_loader 内部のため。logic.py のハンドラで catch → `ResourceNotFoundError` に変換する）
+   - 検証: `uv run python -c "from src.exceptions import AppError, CatalogLoadError, ResourceNotFoundError"` → インポート成功
+
+2. `document-server/src/models.py` にレスポンスモデルを追加。`ErrorDetail(code: str, message: str)`, `ErrorResponse(error: ErrorDetail)`, `ReloadData(status, tables_loaded, terms_loaded, logic_loaded, reload_time_ms, skipped_files)`, `ReloadResponse(data: ReloadData)`, `LogicCodeData(logic_name, language, code)`, `LogicCodeResponse(data: LogicCodeData)` を定義
+   - 検証: `uv run python -c "from src.models import ReloadResponse, LogicCodeResponse, ErrorResponse"` → インポート成功
+
+3. `document-server/src/main.py` に exception_handler 4 種を登録:
+   - `AppError` → `error_response(exc.status_code, exc.code, exc.message)` を返却
+   - `RequestValidationError`（`fastapi.exceptions`）→ 422, `VALIDATION_ERROR`
+   - `pydantic.ValidationError` → 422, `VALIDATION_ERROR`（データ不正として分類。INTERNAL_ERROR にしない）
+   - `Exception` → 500, `INTERNAL_ERROR`（`logger.exception` でログ出力、詳細は非公開）
+   - 検証: `uv run python -c "from src.main import app; from src.exceptions import AppError; from pydantic import ValidationError; from fastapi.exceptions import RequestValidationError; h = app.exception_handlers; assert AppError in h and ValidationError in h and RequestValidationError in h and Exception in h, f'missing: {set([AppError,ValidationError,RequestValidationError,Exception]) - set(h.keys())}'; print('OK: 4 handlers registered')"` → `OK: 4 handlers registered`
+
+4. `document-server/src/routers/admin.py` を修正:
+   - `from ..exceptions import CatalogLoadError` を追加
+   - `except (ValueError, OSError)` で `raise CatalogLoadError() from exc` に変更
+   - `except Exception` ブロックを削除（generic handler に委譲）
+   - 戻り値型を `ReloadResponse` に変更、`response_model=ReloadResponse` を設定
+   - `JSONResponse` インポートを削除
+   - 検証: `grep -n "JSONResponse\|response_model=None\|dict | JSONResponse" document-server/src/routers/admin.py` → 0 件
+
+5. `document-server/src/routers/logic.py` を修正:
+   - `/meta`: `response_model=None` を削除（戻り値は `dict` のまま。`detail_response()` の汎用 dict 構造に型付きモデルを定義するのはオーバースペックのため、OpenAPI には dict スキーマが出る。型付きレスポンスモデルの導入は将来の改善タスクとする）
+   - `/code/{logic_name}`: `except LogicCodeNotFoundError` で `raise ResourceNotFoundError(...)` に変更、`result is None` で同様に raise、戻り値型を `LogicCodeResponse` に変更、`response_model=LogicCodeResponse` を設定
+   - `JSONResponse` / `error_response` インポートを削除
+   - 検証: `grep -n "JSONResponse\|response_model=None\|dict | JSONResponse" document-server/src/routers/logic.py` → 0 件
+
+6. テストを作成・更新（Red フェーズ）:
+   - `test_error_handling.py`（新規）: `test_request_validation_error_unified_format`（空リスト送信→422 + `{"error": {"code": "VALIDATION_ERROR", ...}}`）、`test_generic_exception_returns_internal_error`（意図的に Exception を発生させ→500 + INTERNAL_ERROR）、`test_validation_error_returns_unified_format`（pydantic.ValidationError のシナリオ）
+   - `test_admin_api.py`: `test_reload_failure_keeps_old_catalog` にレスポンスボディの `error.message` 存在チェックを追加
+   - `test_logic_api.py`: `test_get_logic_meta_empty_names` にレスポンスボディの統一形式チェックを追加
+   - 検証: `bash scripts/test.sh --quiet --test --no-lint document-server -- tests/test_error_handling.py tests/test_admin_api.py tests/test_logic_api.py` → Red 確認後、Green まで反復
+
+7. 既存テスト全体の回帰確認:
+   - 検証: `bash scripts/test.sh --quiet document-server` → 全テスト PASS、lint / mypy PASS
+
+### 技術的な考慮事項
+
+- **auth.py の HTTPException との共存**: FastAPI は HTTPException 用の組み込みハンドラを持ち、カスタム Exception ハンドラより優先される。auth の 401 レスポンスは `{"detail": ...}` 形式のまま維持される（統一形式への変更はスコープ外）
+- **`error_response()` の扱い**: exception_handler 内で `error_response()` ヘルパーを再利用する。ルーターからの直接呼び出しはなくなるが、ヘルパー自体は exception_handler 経由で使用されるため削除しない
+- **`LogicCodeNotFoundError` の配置**: `catalog_loader.py` に残す。exceptions.py に移動すると catalog_loader からのインポート方向が逆転し、循環リスクがある。logic.py のハンドラで catch して `ResourceNotFoundError` に変換する
+- **`/meta` の OpenAPI 型付け**: `/meta` は `detail_response()` が返す汎用 dict 構造（`{"data": {"logic": [...], "not_found": [...]}}`）を使っており、`logic` リストの要素型は `LogicMeta.model_dump()` の結果。`detail_response` を使う全エンドポイント（tables/terms/logic の POST）に個別レスポンスモデルを定義するのは大きなスコープ拡大になるため、本タスクでは `/meta` の `response_model=None` 削除に留め、型付きモデルは将来改善とする
+- **pydantic.ValidationError ハンドラの必要性**: FastAPI の `RequestValidationError` はリクエストボディのバリデーション用。データパース時（catalog_loader 内）の `pydantic.ValidationError` は別クラスのため、両方のハンドラが必要。admin.py の try/except で catch される ValidationError はそのまま `CatalogLoadError` に変換されるが、将来的に他のハンドラで未キャッチの ValidationError が発生した場合の安全網として登録する
+- **`skipped_files` の型**: `CatalogStore.skipped_files` は `dict[str, int]` を返す。`ReloadData` モデルの `skipped_files` フィールドは `dict[str, int]` とする（専用モデルにしない — 現在の 3 キー固定構造はコードが正）
+
+## リスクと検知方法
+
+- **auth の 401 レスポンス形式が変わる**: generic Exception ハンドラが HTTPException をキャッチしてしまう可能性 → `test_auth.py` の既存テスト（`test_missing_authorization_header_returns_401` 等）でレスポンスボディ形式が変わっていないことを確認。FastAPI の組み込みハンドラが優先されることを `test_error_handling.py` でも検証
+- **tables.py / terms.py のレスポンスが壊れる**: RequestValidationError ハンドラの追加で既存の 422 レスポンス形式が変わる → `test_logic_api.py:test_get_logic_meta_empty_names` および `test_terms_api.py:test_get_term_details_empty_term_names` でボディ形式を検証
+- **OpenAPI スキーマの破壊**: response_model 設定でレスポンスバリデーションが有効になり、既存レスポンスが model に合わない場合 500 になる → `test_admin_api.py:test_reload_catalog`（正常系）、`test_logic_api.py:test_get_logic_code`（正常系）で 200 + ボディ内容を検証
+
+## 完了条件
+
+- [ ] `grep -n "response_model=None" document-server/src/routers/admin.py document-server/src/routers/logic.py` → 0 件
+- [ ] `grep -n "dict | JSONResponse" document-server/src/routers/admin.py document-server/src/routers/logic.py` → 0 件
+- [ ] `grep -n "from.*responses.*import.*error_response" document-server/src/routers/admin.py document-server/src/routers/logic.py` → 0 件（ルーターが error_response を直接呼ばない）
+- [ ] `bash scripts/test.sh --quiet --test --no-lint document-server -- tests/test_error_handling.py` → PASS（exception_handler の統一形式テスト）
+- [ ] `bash scripts/test.sh --quiet document-server` → 全テスト PASS、lint / mypy PASS
+- [ ] 不正入力時（空リスト等）のレスポンスが `{"error": {"code": "VALIDATION_ERROR", "message": ...}}` 形式であること（`test_error_handling.py` で検証）
+
+## テスト計画
+
+### 既存テストの被覆状況
+
+- `document-server/tests/test_admin_api.py`: reload 失敗時の 400 + `CATALOG_LOAD_ERROR` を検証済み（L88-89）。レスポンス形式の変更なし → 流用（既存テスト通過で回帰なし確認）
+- `document-server/tests/test_logic_api.py`: `/code` の 404 + `LOGIC_NOT_FOUND` / `LOGIC_CODE_NOT_FOUND` を検証済み（L118-149）。`/meta` の 422 はステータスコードのみ検証（L92-94）→ ボディ形式検証を追加
+- `document-server/tests/test_auth.py`: 401 レスポンスのステータスコードを検証済み → 回帰確認に流用
+- `document-server/tests/test_tables_api.py`, `test_terms_api.py`: 正常系の 200 レスポンスを検証済み → 回帰確認に流用
+
+### 新規テスト
+
+- `test_request_validation_error_unified_format`: 空リスト送信で 422 + `{"error": {"code": "VALIDATION_ERROR", ...}}` 形式を検証（完了条件: 不正入力時の統一形式）
+- `test_generic_exception_returns_internal_error`: 意図的に Exception を発生させ 500 + `{"error": {"code": "INTERNAL_ERROR", ...}}` 形式を検証。レスポンスに traceback / exc 文字列が含まれないことも検証（完了条件: exception_handler テスト PASS）
+- `test_auth_401_format_unchanged`: auth の 401 レスポンスが `{"detail": ...}` 形式のままであること（回帰）
+- `test_get_logic_meta_empty_names`（既存更新）: 422 レスポンスのボディに `error.code` / `error.message` が含まれることを追加検証
+
+注: `test_terms_api.py:test_get_term_details_empty_term_names`（L73-75）も同じ RequestValidationError ハンドラの影響を受けるが、`test_error_handling.py` の `test_request_validation_error_unified_format` で汎用的にカバーされるため個別更新は不要。回帰確認はフルゲートテストで担保する
+
+### テスト参照ポインタ（テスト準備フェーズはこの範囲のみ Read する）
+
+| 参照 | パス:行範囲 | 用途 | 注意点 |
+|------|------------|------|--------|
+| 模倣する代表テスト | `document-server/tests/test_admin_api.py:54-101` | エラーレスポンスのアサーションパターン（status_code + json body 検証） | `patch_data_dir` fixture で DATA_DIR を差し替える手法。`monkeypatch.undo()` で元に戻す |
+| fixture / ヘルパー | `document-server/tests/conftest.py:255-306` | `sample_data_dir`, `client` fixture | `client` fixture は lifespan を実行しない（TestClient の仕様）。`app.state` を手動設定 |
+| 規約チートシート | `.claude/skills/testing-strategies/reference/pytest-testing.md` | pytest + FastAPI テスト規約 | |
+
+---
+
+## レビューステータス
+
+- [x] 計画レビュー完了
+- [ ] 実装完了
+- [ ] テスト完了

--- a/document-server/src/exceptions.py
+++ b/document-server/src/exceptions.py
@@ -1,0 +1,35 @@
+"""アプリケーション例外の定義。
+
+exception_handler で捕捉し、統一エラーレスポンスに変換する。
+"""
+
+from __future__ import annotations
+
+
+class AppError(Exception):
+    """アプリケーションエラーの基底クラス。"""
+
+    def __init__(
+        self,
+        status_code: int = 500,
+        code: str = "INTERNAL_ERROR",
+        message: str = "An internal error occurred.",
+    ) -> None:
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        super().__init__(message)
+
+
+class CatalogLoadError(AppError):
+    """カタログ読み込みエラー。"""
+
+    def __init__(self, message: str = "Failed to reload catalog. Check server logs for details.") -> None:
+        super().__init__(status_code=400, code="CATALOG_LOAD_ERROR", message=message)
+
+
+class ResourceNotFoundError(AppError):
+    """リソースが見つからないエラー。"""
+
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(status_code=404, code=code, message=message)

--- a/document-server/src/main.py
+++ b/document-server/src/main.py
@@ -5,13 +5,18 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 
-from fastapi import Depends, FastAPI
+import pydantic
+from fastapi import Depends, FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from fastapi.routing import APIRouter
 
 from .auth import verify_token
 from .catalog_loader import CatalogStore
 from .config import CORS_ORIGINS, DATA_DIR, DATA_ENV
+from .exceptions import AppError
+from .responses import error_response
 from .routers import admin, logic, tables, terms
 
 logging.basicConfig(
@@ -81,3 +86,27 @@ protected_router.include_router(logic.router)
 protected_router.include_router(admin.router)
 
 app.include_router(protected_router)
+
+
+# --- Exception handlers ---
+
+
+@app.exception_handler(AppError)
+async def app_error_handler(_request: Request, exc: AppError) -> JSONResponse:
+    return error_response(exc.status_code, exc.code, exc.message)
+
+
+@app.exception_handler(RequestValidationError)
+async def request_validation_error_handler(_request: Request, exc: RequestValidationError) -> JSONResponse:
+    return error_response(422, "VALIDATION_ERROR", str(exc))
+
+
+@app.exception_handler(pydantic.ValidationError)
+async def pydantic_validation_error_handler(_request: Request, exc: pydantic.ValidationError) -> JSONResponse:
+    return error_response(422, "VALIDATION_ERROR", str(exc))
+
+
+@app.exception_handler(Exception)
+async def generic_exception_handler(_request: Request, exc: Exception) -> JSONResponse:
+    logger.exception("Unhandled exception: %s", exc)
+    return error_response(500, "INTERNAL_ERROR", "Internal server error")

--- a/document-server/src/models.py
+++ b/document-server/src/models.py
@@ -201,3 +201,37 @@ class LogicMeta(BaseModel):
     _strip_notes = field_validator("notes", mode="before")(_strip_string)
     _strip_output_description = field_validator("output_description", mode="before")(_strip_string)
     _strip_usage_context = field_validator("usage_context", mode="before")(_strip_string)
+
+
+# --- Error / wrapper response models ---
+
+
+class ReloadData(BaseModel):
+    """カタログリロード結果のデータ。"""
+
+    status: str
+    tables_loaded: int
+    terms_loaded: int
+    logic_loaded: int
+    reload_time_ms: int
+    skipped_files: dict[str, int]
+
+
+class ReloadResponse(BaseModel):
+    """カタログリロードレスポンス。"""
+
+    data: ReloadData
+
+
+class LogicCodeData(BaseModel):
+    """ロジックコード取得結果のデータ。"""
+
+    logic_name: str
+    language: str
+    code: str
+
+
+class LogicCodeResponse(BaseModel):
+    """ロジックコード取得レスポンス。"""
+
+    data: LogicCodeData

--- a/document-server/src/routers/admin.py
+++ b/document-server/src/routers/admin.py
@@ -6,11 +6,11 @@ import time
 from datetime import UTC, datetime
 
 from fastapi import APIRouter, Request
-from fastapi.responses import JSONResponse
 
 from ..catalog_loader import CatalogStore
 from ..config import DATA_DIR
-from ..responses import error_response
+from ..exceptions import CatalogLoadError
+from ..models import ReloadResponse
 
 logger = logging.getLogger(__name__)
 
@@ -19,10 +19,10 @@ router = APIRouter(prefix="/admin", tags=["admin"])
 _reload_lock = threading.Lock()
 
 
-@router.post("/reload", response_model=None)
+@router.post("/reload", response_model=ReloadResponse)
 def reload_catalog(
     request: Request,
-) -> dict | JSONResponse:
+) -> dict:
     with _reload_lock:
         start = time.monotonic()
         try:
@@ -30,10 +30,7 @@ def reload_catalog(
             loaded = new_store.load_all(DATA_DIR)
         except (ValueError, OSError) as exc:
             logger.error("Catalog reload failed: %s", exc)
-            return error_response(400, "CATALOG_LOAD_ERROR", "Failed to reload catalog. Check server logs for details.")
-        except Exception:
-            logger.exception("Unexpected error during catalog reload")
-            return error_response(500, "INTERNAL_ERROR", "Unexpected error during reload.")
+            raise CatalogLoadError() from exc
         elapsed_ms = int((time.monotonic() - start) * 1000)
         request.app.state.catalog_store = new_store
         request.app.state.last_reload = datetime.now(UTC).isoformat()

--- a/document-server/src/routers/logic.py
+++ b/document-server/src/routers/logic.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends
 from fastapi import Path as FastAPIPath
-from fastapi.responses import JSONResponse
 
 from ..catalog_loader import CatalogStore, LogicCodeNotFoundError
 from ..dependencies import get_catalog_store
-from ..models import LogicMetaRequest
-from ..responses import detail_response, error_response, index_response
+from ..exceptions import ResourceNotFoundError
+from ..models import LogicCodeResponse, LogicMetaRequest
+from ..responses import detail_response, index_response
 
 router = APIRouter(prefix="/logic", tags=["logic"])
 
@@ -18,7 +18,7 @@ def get_logic_index(store: CatalogStore = Depends(get_catalog_store)) -> dict:
     return index_response("logic", logic)
 
 
-@router.post("/meta", response_model=None)
+@router.post("/meta")
 def get_logic_meta(
     request: LogicMetaRequest,
     store: CatalogStore = Depends(get_catalog_store),
@@ -27,19 +27,21 @@ def get_logic_meta(
     return detail_response("logic", [m.model_dump() for m in metas], not_found)
 
 
-@router.get("/code/{logic_name}", response_model=None)
+@router.get("/code/{logic_name}", response_model=LogicCodeResponse)
 def get_logic_code(
     logic_name: str = FastAPIPath(..., pattern=r"^[a-zA-Z0-9_-]+$", max_length=100),
     store: CatalogStore = Depends(get_catalog_store),
-) -> dict | JSONResponse:
+) -> dict:
     try:
         result = store.get_logic_code(logic_name)
     except LogicCodeNotFoundError:
-        return error_response(
-            404,
-            "LOGIC_CODE_NOT_FOUND",
-            f"Code file for logic '{logic_name}' not found",
-        )
+        raise ResourceNotFoundError(
+            code="LOGIC_CODE_NOT_FOUND",
+            message=f"Code file for logic '{logic_name}' not found",
+        ) from None
     if result is None:
-        return error_response(404, "LOGIC_NOT_FOUND", f"Logic '{logic_name}' not found")
+        raise ResourceNotFoundError(
+            code="LOGIC_NOT_FOUND",
+            message=f"Logic '{logic_name}' not found",
+        )
     return {"data": result}

--- a/document-server/tests/test_admin_api.py
+++ b/document-server/tests/test_admin_api.py
@@ -84,9 +84,11 @@ def test_reload_failure_keeps_old_catalog(
     # Act: reload を実行（失敗を期待）
     resp_reload = client.post("/admin/reload")
 
-    # Assert: 400 + CATALOG_LOAD_ERROR
+    # Assert: 400 + CATALOG_LOAD_ERROR + message 存在
     assert resp_reload.status_code == 400
-    assert resp_reload.json()["error"]["code"] == "CATALOG_LOAD_ERROR"
+    error = resp_reload.json()["error"]
+    assert error["code"] == "CATALOG_LOAD_ERROR"
+    assert "message" in error
 
     # 旧データが維持されていること
     monkeypatch.undo()

--- a/document-server/tests/test_error_handling.py
+++ b/document-server/tests/test_error_handling.py
@@ -1,0 +1,132 @@
+"""exception_handler のユニットテスト。
+
+タスク 9.3: エラーレスポンス機構の統一
+- RequestValidationError -> 422 + {"error": {"code": "VALIDATION_ERROR", ...}} 形式
+- generic Exception -> 500 + {"error": {"code": "INTERNAL_ERROR", ...}} 形式
+- auth 401 は {"detail": ...} 形式を維持（回帰テスト）
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_request_validation_error_unified_format(client: TestClient) -> None:
+    """空リスト送信で 422 + {"error": {"code": "VALIDATION_ERROR", ...}} 形式を検証。"""
+    # Act: BulkNameList の min_length=1 に違反
+    resp = client.post("/logic/meta", json={"logic_names": []})
+
+    # Assert: 422 + 統一エラー形式
+    assert resp.status_code == 422
+    body = resp.json()
+    assert "error" in body, f"Expected 'error' key in response, got: {body}"
+    error = body["error"]
+    assert error["code"] == "VALIDATION_ERROR"
+    assert "message" in error
+    assert isinstance(error["message"], str)
+    assert len(error["message"]) > 0
+    # FastAPI デフォルト形式 {"detail": [...]} ではないこと
+    assert "detail" not in body
+
+
+def test_generic_exception_returns_internal_error(
+    sample_data_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """意図的に Exception を発生させ 500 + 統一形式を検証。traceback が含まれないこと。"""
+    from src.catalog_loader import CatalogStore
+    from src.main import app
+
+    # Arrange: 正常な状態を構築
+    store = CatalogStore()
+    store.load_tables(sample_data_dir)
+    store.load_terms(sample_data_dir)
+    store.load_logic(sample_data_dir)
+    app.state.catalog_store = store
+    app.state.last_reload = "2024-01-01T00:00:00+00:00"
+
+    # catalog_store のメソッドで予期しない例外を発生させる
+    def _raise_unexpected() -> None:
+        raise RuntimeError("unexpected failure")
+
+    monkeypatch.setattr(store, "get_all_logic_indexes", _raise_unexpected)
+
+    # raise_server_exceptions=False で TestClient を作成
+    # （例外が TestClient に伝播しないようにする）
+    test_client = TestClient(app, raise_server_exceptions=False)
+    test_client.headers.update({"Authorization": "Bearer test-token"})
+
+    # Act
+    resp = test_client.get("/logic/index")
+
+    # Assert: 500 + 統一形式
+    assert resp.status_code == 500
+    body = resp.json()
+    assert "error" in body, f"Expected 'error' key in response, got: {body}"
+    error = body["error"]
+    assert error["code"] == "INTERNAL_ERROR"
+    assert "message" in error
+    # traceback / exc 文字列がレスポンスに含まれないこと
+    body_str = str(body)
+    assert "traceback" not in body_str.lower()
+    assert "unexpected failure" not in body_str
+
+
+def test_catalog_load_error_does_not_leak_internal_details(
+    client: TestClient,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """カタログリロード失敗時にサーバー内部パスやYAML例外詳細がレスポンスに漏れないこと。"""
+    import src.routers.admin as admin_module
+
+    # Arrange: 壊れた YAML を持つデータディレクトリを作成
+    broken_dir = tmp_path / "broken"
+    broken_dir.mkdir()
+    catalog_dir = broken_dir / "catalog"
+    catalog_dir.mkdir()
+    (catalog_dir / "index.yaml").write_text(
+        "tables_index:\n  - {invalid yaml: [unterminated",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(admin_module, "DATA_DIR", broken_dir)
+
+    # Act: reload を実行（失敗を期待）
+    resp = client.post("/admin/reload")
+
+    # Assert: 400 + CATALOG_LOAD_ERROR
+    assert resp.status_code == 400
+    body = resp.json()
+    assert "error" in body
+    error = body["error"]
+    assert error["code"] == "CATALOG_LOAD_ERROR"
+
+    # セキュリティ: 内部詳細がレスポンスに漏れないこと
+    msg = error["message"]
+    assert "data/" not in msg, f"Internal path leaked in message: {msg}"
+    assert "traceback" not in msg.lower(), f"Traceback leaked in message: {msg}"
+    assert "yaml" not in msg.lower(), f"YAML parser details leaked in message: {msg}"
+    assert "index.yaml" not in msg, f"Internal filename leaked in message: {msg}"
+    assert tmp_path.name not in msg, f"Temp path leaked in message: {msg}"
+
+
+def test_auth_401_format_unchanged() -> None:
+    """auth の 401 レスポンスが {"detail": ...} 形式のままであること（回帰）。"""
+    from src.main import app
+
+    # 認証なしの TestClient（auth 依存が先に発火するため catalog state 不要）
+    unauthenticated_client = TestClient(app)
+
+    # Act: 認証ヘッダーなしでアクセス
+    resp = unauthenticated_client.get("/catalog/index")
+
+    # Assert: HTTPException の {"detail": "..."} 形式が維持されること
+    assert resp.status_code == 401
+    body = resp.json()
+    assert "detail" in body
+    # 統一エラー形式に巻き込まれていないこと
+    assert "error" not in body

--- a/document-server/tests/test_logic_api.py
+++ b/document-server/tests/test_logic_api.py
@@ -92,6 +92,11 @@ def test_get_logic_meta_all_not_found(client: TestClient) -> None:
 def test_get_logic_meta_empty_names(client: TestClient) -> None:
     resp = client.post("/logic/meta", json={"logic_names": []})
     assert resp.status_code == 422
+    body = resp.json()
+    assert "error" in body, f"Expected 'error' key in response, got: {body}"
+    error = body["error"]
+    assert error["code"] == "VALIDATION_ERROR"
+    assert "message" in error
 
 
 # --- GET /logic/code/{logic_name} ---


### PR DESCRIPTION
## Summary

- document-server の `dict | JSONResponse` 戻り値パターンを exception_handler ベースへ統一（タスク 9.3、`tmp/refactor-notes.md` §3-3/3-4）
- `src/exceptions.py` を新設し `AppError` / `CatalogLoadError` / `ResourceNotFoundError` を定義。`main.py` に AppError / RequestValidationError / pydantic.ValidationError / Exception の 4 種の exception_handler を登録
- `admin.py` / `logic.py` の `response_model=None` を解消し、`ReloadResponse` / `LogicCodeResponse` で OpenAPI にレスポンス型を復活
- Pydantic ValidationError を INTERNAL_ERROR ではなく 422 VALIDATION_ERROR（データ不正）として分類
- auth の 401 レスポンスは `{"detail": ...}` 形式のまま維持（スコープ外の設計判断、回帰テストで固定）
- `tests/test_error_handling.py` を新設（統一形式・内部情報非漏洩・401 形式回帰の検証）
- Phase 9 全タスク完了に伴い、plan のステータス更新とアーカイブ退避を実施

## Test plan

- `bash scripts/test.sh --quiet document-server` → lint / mypy / 全テスト PASS 確認済み
- 完了条件の grep 検証（`response_model=None`・`dict | JSONResponse`・`error_response` 直接参照が 0 件）を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H2QY4nUNMbpXPZUssSh41g
