### PR TITLE
chore: ruff ASYNC ルールを有効化し I3 の機械検知を導入（タスク 11.2）

### DIFF
--- a/.claude/rules/lint.md
+++ b/.claude/rules/lint.md
@@ -14,6 +14,13 @@ paths:
 
 - 反復中のスコープ実行（`.claude/rules/tdd.md` の「テスト実行コマンドの規律」参照）。保存時の自動整形は format-on-save hook が担い、フェーズ締めのフルゲート（lint 込みの `scripts/test.sh --quiet {コンポーネント名}`）を必ず通すこと
 
+## ruff ASYNC ルールの方針（Python 3 コンポーネント）
+
+`docs/design/invariants.md` の I3（async コンテキストでブロッキング I/O をしない）を機械検知するため、ruff の `ASYNC` を `select` に入れている。選択状況・抑制対象の具体は各コンポーネントの `pyproject.toml` が正。
+
+- **ASYNC240 は部分的な網であり、I3 の保証ではない。** ruff は `Path(p).resolve()` のように `Path(...)` から直接メソッドを呼ぶ形は検知するが、`d = Path(root) / name` のように join を挟むと型推論が切れて以降のメソッド呼び出しを検知しない。pandas の `df.to_csv()` のようなライブラリ経由の I/O も原理的に検知できない。**ゲートがグリーンでも async 関数内のブロッキング I/O は残りうる**ため、レビュー時は目視でも確認する。オフロードが必要な場合は `_{名前}_sync()` を定義して `loop.run_in_executor(None, ...)` から呼ぶ既存イディオムに揃える
+- **ASYNC109（async 関数の `timeout` 引数）はコンポーネント全体の `ignore` にせず、`[tool.ruff.lint.per-file-ignores]` で既存の該当ファイルに限定する。** `timeout` は REST API が公開するパラメータの契約であり、ロック取得後の deadline 計算や二段構えのタイムアウトなど呼び出し側の `asyncio.timeout` では代替できない実装になっているため抑制自体は妥当だが、全体 `ignore` にすると将来の新規 async 関数まで恒久的に検知外になる。新規ファイルで ASYNC109 が出た場合は、抑制対象を増やす前に `asyncio.timeout` で代替できないかを検討する
+
 ## lint 失敗時の対応
 
 1. `lint.sh` のエラー出力から問題箇所と原因を読み取る

--- a/docs/plan/01-jupyter.md
+++ b/docs/plan/01-jupyter.md
@@ -26,3 +26,13 @@ Phase 22（jupyter-mcp 構造改善）で主要部分は解消したが、境界
 |---|--------|-----------|-----------|------|
 | 25.1 | session-resolver: 接続断とリソース未発見の区別 | [ ] | jupyter-server 停止中に session 系ツールを呼ぶと「接続不可」と分かるエラーが返り、存在しない session_id の場合と区別できる | `utils/session-resolver.ts:55-61` が listSessions 失敗時に stale キャッシュへフォールバックし、再起動後に誤誘導する |
 | 25.2 | jupyter-client の未検証レスポンスへの zod 適用 | [ ] | 契約違反のレスポンスを返すモックに対し、「形式不正」と分かるエラーが返る（`Cannot read properties of undefined` にならない） | `jupyter-client/client.ts` の `getVariable` / `getFileContent` が `validateResponse` を経由していない。不変条件 I4 |
+
+---
+
+## Phase 26: ruff で検知できない I3 違反の解消
+
+タスク 11.2（ruff ASYNC ルールの有効化）のスコープ外として残した、ライブラリ経由のブロッキング I/O。ruff の ASYNC240 は pandas 等のライブラリ呼び出しを原理的に検知できないため（`.claude/rules/lint.md` の「ruff ASYNC ルールの方針」参照）、ゲートがグリーンでも残存する。
+
+| # | タスク | ステータス | E2Eテスト | 備考 |
+|---|--------|-----------|-----------|------|
+| 26.1 | SQL エクスポートの CSV 書き出しをオフロード | [ ] | 大量行の SQL エクスポート実行中に別リクエスト（セッション一覧取得等）を投げても待たされずに応答が返る。書き出し中にディスクエラーが起きた場合はエラーレスポンスが返り、握りつぶされない | `sql_handlers.py:697` の `df.to_csv()` が最大 100 万行を event loop 上で書き出す。不変条件 I3 違反だが ruff では検知できない。既存の `_export_sql_sync` / `run_in_executor` イディオムに揃える |

--- a/docs/plan/04-infrastructure.md
+++ b/docs/plan/04-infrastructure.md
@@ -13,9 +13,9 @@
 | # | タスク | ステータス | E2Eテスト | 備考 |
 |---|--------|-----------|-----------|------|
 | 11.1 | ADR・横断不変条件・タスク設計ルールの整備 | [x] | 計画作成時に異常系AC・不変条件・ADR要否のチェックが要求され、/custom-debt-review で横断監査が実行できる | docs/adr/（テンプレ+0001）、docs/design/invariants.md（I1〜I8）、task-design.md チェックリスト拡張、change-requirement に異常系レンズ追加 |
-| 11.2 | ruff ASYNC ルールの有効化 | [ ] | async 関数内のブロッキング I/O を含む PR で `scripts/lint.sh jupyter-server` が exit 1 になる | 不変条件 I3 の機械検知。CI 変更は不要（既存 python-lint-and-test が拾う）。既存違反 5 件は実測済み |
+| 11.2 | ruff ASYNC ルールの有効化 | [x] | async 関数内のブロッキング I/O を含む PR で `scripts/lint.sh jupyter-server` が exit 1 になる | 不変条件 I3 の機械検知。CI 変更は不要（既存 python-lint-and-test が拾う）。既存違反 5 件は実測済み |
 | 11.3 | ファイルサイズ予算の CI 検知 | [ ] | 予算超過ファイルを含む PR で CI の fitness-functions ジョブが FAIL する | ラチェット方式（現状をベースライン化し悪化のみブロック）。ベースラインは 11.2 完了後に採取する |
 | 11.4 | コピペ検出（jscpd・informational） | [ ] | 重複率が閾値を超えた PR で jscpd ステップが赤くなる（CI はブロックしない） | 不変条件 I8 の可視化。誤検知の切り分け期間として informational から開始する |
 
-> Phase 11.2〜11.4 の分割根拠と実測ベースラインは `docs/tasks/infrastructure/11.2-ruff-async-rules.md` の「背景: 3ゲートの実測」を参照。
+> Phase 11.2〜11.4 の分割根拠と実測ベースラインは `docs/tasks/archive/infrastructure/11.2-ruff-async-rules.md` の「背景: 3ゲートの実測」を参照。
 

--- a/docs/tasks/archive/infrastructure/11.2-ruff-async-rules.md
+++ b/docs/tasks/archive/infrastructure/11.2-ruff-async-rules.md
@@ -219,17 +219,17 @@ ADR 要否: 不要。状態の所有権・コンポーネント間契約・方�
 
 本文からは番号ではなく**アンカー語**で参照する（条件の挿入で番号がずれても壊れないようにするため）。
 
-- [ ] **（select 有効化）** `jupyter-server` / `document-server` / `scripts` の 3 つの `pyproject.toml` の `select` に `"ASYNC"` が含まれる（`grep -c ASYNC` が各ファイルで 1 以上）
-- [ ] **（全体グリーン）** `uv run ruff check jupyter-server/extensions/ jupyter-server/tests/ document-server/src/ document-server/tests/ scripts/*.py scripts/lib/*.py` が exit 0
-- [ ] **（異常系: ゲート回帰）** ゲート自体の回帰テストが pass する（意図的な `async def` 内 `Path(p).resolve()` に対して ruff が exit 1 と `ASYNC240` を返す。ソースツリーにプローブファイルは作らない）
-- [ ] **（ASYNC240 解消）** `uv run ruff check --statistics jupyter-server/extensions/` の出力に `ASYNC240` が 0 件（`ASYNC109` は `per-file-ignores` により出力されない）
-- [ ] **（抑制の限定）** ASYNC109 の抑制が 2 ファイルに限定されている（`jupyter-server/pyproject.toml` に `[tool.ruff.lint.per-file-ignores]` があり、`ignore` に `ASYNC109` が**含まれない**こと）
-- [ ] **（異常系: cwd 解決）** ワークスペースルート外の cwd を渡すと `_resolve_workspace_id_from_cwd_sync` が `ValueError` を送出し、`resolve_workspace_for_kernel` 経由では `(None, None)` が返る（新規テストのケース 2 と 5 で検証）
-- [ ] **（jupyter 回帰）** `scripts/test.sh --quiet jupyter-server` が pass（既存テスト全体に副作用がないこと。なお既存テストは変更対象の関数に到達しないため、この条件は副作用の検知であって本タスクの回帰検知ではない）
-- [ ] **（document 回帰）** `scripts/test.sh --quiet document-server` が pass
-- [ ] **（lint 全体）** `scripts/lint.sh` が `All checks passed.` を出力し exit 0
-- [ ] **（ドキュメント）** `.claude/rules/lint.md` に ASYNC240 の検知限界と、ASYNC109 を `per-file-ignores` で 2 ファイルに限定する理由が記載されている
-- [ ] **（残債の起票）** `sql_handlers.py:697` の `df.to_csv()` オフロードが別タスクとして `docs/plan/01-jupyter.md` に起票されている
+- [x] **（select 有効化）** `jupyter-server` / `document-server` / `scripts` の 3 つの `pyproject.toml` の `select` に `"ASYNC"` が含まれる（`grep -c ASYNC` が各ファイルで 1 以上）
+- [x] **（全体グリーン）** `uv run ruff check jupyter-server/extensions/ jupyter-server/tests/ document-server/src/ document-server/tests/ scripts/*.py scripts/lib/*.py` が exit 0
+- [x] **（異常系: ゲート回帰）** ゲート自体の回帰テストが pass する（意図的な `async def` 内 `Path(p).resolve()` に対して ruff が exit 1 と `ASYNC240` を返す。ソースツリーにプローブファイルは作らない）
+- [x] **（ASYNC240 解消）** `uv run ruff check --statistics jupyter-server/extensions/` の出力に `ASYNC240` が 0 件（`ASYNC109` は `per-file-ignores` により出力されない）
+- [x] **（抑制の限定）** ASYNC109 の抑制が 2 ファイルに限定されている（`jupyter-server/pyproject.toml` に `[tool.ruff.lint.per-file-ignores]` があり、`ignore` に `ASYNC109` が**含まれない**こと）
+- [x] **（異常系: cwd 解決）** ワークスペースルート外の cwd を渡すと `_resolve_workspace_id_from_cwd_sync` が `ValueError` を送出し、`resolve_workspace_for_kernel` 経由では `(None, None)` が返る（新規テストのケース 2 と 5 で検証）
+- [x] **（jupyter 回帰）** `scripts/test.sh --quiet jupyter-server` が pass（既存テスト全体に副作用がないこと。なお既存テストは変更対象の関数に到達しないため、この条件は副作用の検知であって本タスクの回帰検知ではない）
+- [x] **（document 回帰）** `scripts/test.sh --quiet document-server` が pass
+- [x] **（lint 全体）** `scripts/lint.sh` が `All checks passed.` を出力し exit 0
+- [x] **（ドキュメント）** `.claude/rules/lint.md` に ASYNC240 の検知限界と、ASYNC109 を `per-file-ignores` で 2 ファイルに限定する理由が記載されている
+- [x] **（残債の起票）** `sql_handlers.py:697` の `df.to_csv()` オフロードが別タスクとして `docs/plan/01-jupyter.md` に起票されている
 
 ## テスト計画
 
@@ -268,5 +268,5 @@ ADR 要否: 不要。状態の所有権・コンポーネント間契約・方�
 ## レビューステータス
 
 - [x] 計画レビュー完了
-- [ ] 実装完了
-- [ ] テスト完了
+- [x] 実装完了
+- [x] テスト完了

--- a/document-server/pyproject.toml
+++ b/document-server/pyproject.toml
@@ -27,7 +27,7 @@ target-version = "py311"
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "B", "SIM"]
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "ASYNC"]
 ignore = ["E501", "B008"]
 
 [tool.ruff.lint.isort]

--- a/jupyter-server/extensions/custom_api/cell_handlers.py
+++ b/jupyter-server/extensions/custom_api/cell_handlers.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import copy as _copy
 import logging
 import re
@@ -34,6 +35,17 @@ log = logging.getLogger(__name__)
 # =============================================================================
 # ヘルパー関数
 # =============================================================================
+
+
+def _resolve_workspace_id_from_cwd_sync(cwd: str) -> str | None:
+    """カーネルの cwd からワークスペース ID を推定する（同期のパス解決を含む）。
+
+    cwd がワークスペースルート配下にない場合、relative_to が ValueError を送出する。
+    呼び出し側の except で捕捉される想定。
+    """
+    workspace_root = Path(WORKSPACE_ROOT_DIR).resolve()
+    rel = Path(cwd).resolve().relative_to(workspace_root)
+    return str(rel.parts[0]) if rel.parts else None
 
 
 async def resolve_workspace_for_kernel(handler: BaseCustomHandler, kernel_id: str) -> tuple[Path | None, str | None]:
@@ -84,10 +96,8 @@ async def resolve_workspace_for_kernel(handler: BaseCustomHandler, kernel_id: st
                 if provisioner:
                     cwd = getattr(provisioner, "cwd", None)
             if cwd:
-                workspace_root = Path(WORKSPACE_ROOT_DIR).resolve()
-                rel = Path(cwd).resolve().relative_to(workspace_root)
-                if rel.parts:
-                    workspace_id = str(rel.parts[0])
+                loop = asyncio.get_running_loop()
+                workspace_id = await loop.run_in_executor(None, _resolve_workspace_id_from_cwd_sync, cwd)
         except Exception as exc:
             if isinstance(exc, ValueError):
                 log.info("Failed to resolve workspace from kernel cwd", exc_info=True)

--- a/jupyter-server/pyproject.toml
+++ b/jupyter-server/pyproject.toml
@@ -19,8 +19,16 @@ target-version = "py311"
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "B", "SIM"]
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "ASYNC"]
 ignore = ["E501"]
+
+# ASYNC109: REST API が timeout パラメータを公開する契約のため、async 関数が
+# timeout 引数を取るのは意図的。内部でロック取得後の deadline 計算や
+# asyncio.wait_for(..., timeout + 5) の二段構えを行っており、呼び出し側の
+# asyncio.timeout では代替できない。新規ファイルでは検知させたいため全体 ignore にはしない
+[tool.ruff.lint.per-file-ignores]
+"extensions/custom_api/kernel_executor.py" = ["ASYNC109"]
+"extensions/custom_api/sql_handlers.py" = ["ASYNC109"]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/jupyter-server/tests/conftest.py
+++ b/jupyter-server/tests/conftest.py
@@ -4,9 +4,16 @@ pytest conftest.py — テストセッション全体の共有フィクスチャ
 custom_api.__init__ を tests/test_kernel_crash_recovery.py から
 `from custom_api import __init__ as init_module` でアクセスできるよう、
 セッション開始時に custom_api パッケージの __init__ 属性を設定する。
+
+あわせて、sandbox コードが書き換えるグローバル属性をテストごとに復元する
+（下記 restore_sandbox_patched_globals を参照）。
 """
 
+import asyncio
+import builtins
 import importlib.util
+import os
+import subprocess
 import sys
 import types
 from pathlib import Path
@@ -14,6 +21,39 @@ from pathlib import Path
 import pytest
 
 _ext_dir = Path(__file__).resolve().parent.parent / "extensions"
+
+# workspace_sandbox.generate_sandbox_code() が返すコードは、多層防御として
+# プロセス全体の builtins / os / subprocess / asyncio / pathlib.Path の属性を差し替える
+# （builtins.open・os.chdir・os.system・subprocess.run・Path.open 等。
+# 対象は workspace_sandbox.py が正）。
+# このコードを exec() するテスト（test_ipython_magic_disable.py /
+# test_kernel_crash_recovery.py / test_workspace_sandbox.py）は差し替えを元に戻さないため、
+# 復元しないと以降の全テストが sandbox の効いた状態で走る。
+# builtins を外すと、パッチ済み open が他 WS パスを PermissionError で拒否する状態が
+# ファイルを跨いで残る（さらに次の exec が _sandbox_open を多重にラップする）。
+_SANDBOX_PATCHED_MODULES = (asyncio, builtins, os, subprocess)
+
+
+@pytest.fixture(autouse=True)
+def restore_sandbox_patched_globals():
+    """sandbox コードによるグローバル属性の書き換えをテストごとに巻き戻す。
+
+    autouse かつ conftest 定義のため、テストモジュール側の autouse フィクスチャより
+    先に入って後に出る。これによりテスト境界を越えて汚染が漏れない。
+    """
+    saved_modules = [(module, dict(vars(module))) for module in _SANDBOX_PATCHED_MODULES]
+    saved_path = {name: value for name, value in vars(Path).items() if not name.startswith("__")}
+
+    yield
+
+    for module, saved in saved_modules:
+        for name, original in saved.items():
+            if getattr(module, name, None) is not original:
+                setattr(module, name, original)
+
+    for name, original in saved_path.items():
+        if getattr(Path, name, None) is not original:
+            setattr(Path, name, original)
 
 
 def _load_init_module():

--- a/jupyter-server/tests/test_workspace_cwd_resolution.py
+++ b/jupyter-server/tests/test_workspace_cwd_resolution.py
@@ -1,0 +1,274 @@
+"""カーネル cwd からのワークスペース解決（I3: async でブロッキング I/O をしない）のユニットテスト
+
+タスク 11.2「ruff ASYNC ルールの有効化」の Red フェーズ。
+
+- `_resolve_workspace_id_from_cwd_sync()`: `resolve_workspace_for_kernel` のブロック 3 から
+  切り出す同期ヘルパー（正常系・異常系・境界値）
+- `resolve_workspace_for_kernel`: 上記ヘルパーを `run_in_executor` でオフロードしていること、
+  および executor 越しの `ValueError` が既存の `except Exception` に届くこと
+- ruff ASYNC ゲート自体の回帰テスト（stdin モードで実行しソースツリーを汚さない）
+
+cell_handlers.py は Tornado/Jupyter の重い依存を持つため、モジュールロードのパターンは
+test_cell_execute_batch.py:19-130 を模倣する（`custom_api.session_handlers` のモックが必須。
+`resolve_workspace_for_kernel` が関数内で `from .session_handlers import get_kernel_workspace`
+を行うため、未登録だと実物がロードされ ImportError になる）。
+"""
+
+import asyncio
+import importlib.util
+import inspect
+import subprocess
+import sys
+import types as _types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+_ext_dir = Path(__file__).resolve().parent.parent / "extensions"
+_repo_root = Path(__file__).resolve().parent.parent.parent
+
+# --- 1. 重い依存のモック ---
+for _mod_name in ("pandas", "sqlalchemy", "sqlalchemy.exc", "tornado", "tornado.web"):
+    if _mod_name not in sys.modules:
+        _m = _types.ModuleType(_mod_name)
+        if _mod_name == "tornado.web":
+            _m.authenticated = lambda f: f
+        sys.modules[_mod_name] = _m
+
+# --- 2. custom_api パッケージ構造の構築 ---
+if "custom_api" not in sys.modules:
+    _pkg = _types.ModuleType("custom_api")
+    _pkg.__path__ = [str(_ext_dir / "custom_api")]
+    _pkg.__package__ = "custom_api"
+    sys.modules["custom_api"] = _pkg
+
+# base モジュールのモック
+if "custom_api.base" not in sys.modules:
+    _base_mock = _types.ModuleType("custom_api.base")
+    _base_mock.__package__ = "custom_api"
+    _base_mock.BaseCustomHandler = type("BaseCustomHandler", (), {})
+    _base_mock.resolve_workspace_dir = lambda *a, **kw: None
+    _base_mock.validate_timeout = lambda *a, **kw: (30, None)
+    _base_mock.validate_workspace_id = lambda *a, **kw: None
+    _base_mock.workspace_contents_path = lambda ws_id: f"workspaces/sample/{ws_id}"
+    _base_mock.utc_now_iso = lambda: "2026-01-01T00:00:00Z"
+    _base_mock.WORKSPACE_ROOT_DIR = "/home/jovyan/work/workspaces/sample"
+    _base_mock.WORKSPACE_PATH_PREFIX = "workspaces/sample"
+    _base_mock.JUPYTER_ROOT_DIR = "/home/jovyan/work"
+    _base_mock.validate_kernel_name = lambda *a, **kw: None
+    _base_mock._apply_lock_token = lambda handler: None
+    _base_mock._build_timeout_error_result = lambda *a, **kw: {}
+
+    def _real_validate_path(user_input, base_dir="/home/jovyan/work"):
+        if not user_input:
+            return ""
+        clean_path = user_input.lstrip("/")
+        base = Path(base_dir).resolve()
+        target = (base / clean_path).resolve()
+        try:
+            target.relative_to(base)
+        except ValueError:
+            raise ValueError(f"不正なパスです: {user_input}") from None
+        return clean_path
+
+    _base_mock.validate_path = _real_validate_path
+    sys.modules["custom_api.base"] = _base_mock
+
+# ai_events モジュールのモック
+if "custom_api.ai_events" not in sys.modules:
+    _ai_events_mock = _types.ModuleType("custom_api.ai_events")
+    _ai_events_mock.__package__ = "custom_api"
+    _ai_events_mock.AiEventsWebSocketHandler = type("AiEventsWebSocketHandler", (), {})
+    _ai_events_mock.AiEventsPostHandler = type("AiEventsPostHandler", (), {})
+    sys.modules["custom_api.ai_events"] = _ai_events_mock
+
+# code_validator モジュール（実際にロード — 純粋関数のため）
+if "custom_api.code_validator" not in sys.modules:
+    _cv_path = _ext_dir / "custom_api" / "code_validator.py"
+    _cv_spec = importlib.util.spec_from_file_location(
+        "custom_api.code_validator", _cv_path, submodule_search_locations=[]
+    )
+    _cv_mod = importlib.util.module_from_spec(_cv_spec)
+    _cv_mod.__package__ = "custom_api"
+    sys.modules["custom_api.code_validator"] = _cv_mod
+    _cv_spec.loader.exec_module(_cv_mod)
+
+# kernel_executor モジュールのモック
+if "custom_api.kernel_executor" not in sys.modules:
+    _ke_mock = _types.ModuleType("custom_api.kernel_executor")
+    _ke_mock.__package__ = "custom_api"
+    _ke_mock.KernelExecutor = MagicMock
+    sys.modules["custom_api.kernel_executor"] = _ke_mock
+
+# session_handlers モジュールのモック（resolve_workspace_for_kernel の関数内 import に必須）
+if "custom_api.session_handlers" not in sys.modules:
+    _sh_mock = _types.ModuleType("custom_api.session_handlers")
+    _sh_mock.__package__ = "custom_api"
+    _sh_mock.CustomSessionsHandler = type("CustomSessionsHandler", (), {})
+    _sh_mock.get_kernel_workspace = lambda *a: None
+    _sh_mock.unregister_kernel = lambda *a: None
+    sys.modules["custom_api.session_handlers"] = _sh_mock
+
+# sql_handlers モジュールのモック
+if "custom_api.sql_handlers" not in sys.modules:
+    _sql_mock = _types.ModuleType("custom_api.sql_handlers")
+    _sql_mock.__package__ = "custom_api"
+    _sql_mock.SqlExecuteHandler = type("SqlExecuteHandler", (), {})
+    _sql_mock.SqlExportHandler = type("SqlExportHandler", (), {})
+    _sql_mock.shutdown_engines = lambda: None
+    sys.modules["custom_api.sql_handlers"] = _sql_mock
+
+# workspace_handlers モジュールのモック
+if "custom_api.workspace_handlers" not in sys.modules:
+    _wh_mock = _types.ModuleType("custom_api.workspace_handlers")
+    _wh_mock.__package__ = "custom_api"
+    _wh_mock.WorkspaceHandler = type("WorkspaceHandler", (), {})
+    _wh_mock.WorkspacesHandler = type("WorkspacesHandler", (), {})
+    _wh_mock.WorkspaceSummarizeHandler = type("WorkspaceSummarizeHandler", (), {})
+    sys.modules["custom_api.workspace_handlers"] = _wh_mock
+
+# --- 3. cell_handlers モジュールをロード ---
+if "custom_api.cell_handlers" not in sys.modules:
+    _cell_module_path = _ext_dir / "custom_api" / "cell_handlers.py"
+    _cell_handlers_spec = importlib.util.spec_from_file_location(
+        "custom_api.cell_handlers",
+        _cell_module_path,
+        submodule_search_locations=[],
+    )
+    _cell_handlers = importlib.util.module_from_spec(_cell_handlers_spec)
+    _cell_handlers.__package__ = "custom_api"
+    sys.modules["custom_api.cell_handlers"] = _cell_handlers
+    _cell_handlers_spec.loader.exec_module(_cell_handlers)
+else:
+    _cell_handlers = sys.modules["custom_api.cell_handlers"]
+
+# cell_handlers がロード時に取り込んだ WORKSPACE_ROOT_DIR（モック値）を正とする
+WORKSPACE_ROOT = _cell_handlers.WORKSPACE_ROOT_DIR
+
+# ワークスペースルート外の cwd（macOS では /private/etc に解決されるがルート外である点は変わらない）
+OUTSIDE_ROOT_CWD = "/etc"
+
+
+def _make_handler(cwd: str | None) -> MagicMock:
+    """resolve_workspace_for_kernel に渡すハンドラのモックを組み立てる。
+
+    - session_manager なし（ブロック 1 をスキップ）
+    - get_kernel_workspace は None を返す（session_handlers モック。ブロック 2 をスキップ）
+    - kernel_manager.get_kernel() が指定 cwd を持つカーネルを返す（ブロック 3 に到達）
+    """
+    handler = MagicMock()
+    handler.settings = {}
+    handler.kernel_manager.get_kernel.return_value = SimpleNamespace(cwd=cwd)
+    return handler
+
+
+class TestResolveWorkspaceIdFromCwdSync:
+    """同期ヘルパー _resolve_workspace_id_from_cwd_sync の単体テスト"""
+
+    def test_returns_workspace_id_for_cwd_under_root(self):
+        """正常系: ワークスペースルート配下の cwd から workspace_id を返す"""
+        cwd = f"{WORKSPACE_ROOT}/ws-a/sub"
+
+        result = _cell_handlers._resolve_workspace_id_from_cwd_sync(cwd)
+
+        assert result == "ws-a"
+
+    def test_raises_value_error_for_cwd_outside_root(self):
+        """異常系: ワークスペースルート外の cwd では ValueError を送出する"""
+        with pytest.raises(ValueError):
+            _cell_handlers._resolve_workspace_id_from_cwd_sync(OUTSIDE_ROOT_CWD)
+
+    def test_returns_none_when_cwd_is_root_itself(self):
+        """境界値: cwd がルート自身のとき rel.parts が空になり None を返す"""
+        result = _cell_handlers._resolve_workspace_id_from_cwd_sync(WORKSPACE_ROOT)
+
+        assert result is None
+
+
+class TestResolveWorkspaceForKernelOffload:
+    """resolve_workspace_for_kernel が run_in_executor でオフロードしていることの検証"""
+
+    @pytest.mark.asyncio
+    async def test_offloads_via_run_in_executor(self, monkeypatch, tmp_path):
+        """同期ヘルパーが loop.run_in_executor 経由で呼ばれる（直接呼び出しの実装ミスを検知）"""
+        # resolve_workspace_for_kernel が coroutine function（async def）のままであること
+        assert inspect.iscoroutinefunction(_cell_handlers.resolve_workspace_for_kernel)
+
+        # Arrange: 実行中の loop インスタンスの run_in_executor だけを spy する
+        # （asyncio.get_running_loop のグローバル patch は他テストに波及するため使わない）
+        loop = asyncio.get_running_loop()
+        original_run_in_executor = loop.run_in_executor
+        calls = []
+
+        def _spy(executor, func, *args):
+            calls.append((func, args))
+            return original_run_in_executor(executor, func, *args)
+
+        monkeypatch.setattr(loop, "run_in_executor", _spy)
+        monkeypatch.setattr(_cell_handlers, "resolve_workspace_dir", lambda ws_id: tmp_path / ws_id)
+
+        handler = _make_handler(cwd=f"{WORKSPACE_ROOT}/ws-a/sub")
+
+        # Act
+        output_dir, workspace_rel_path = await _cell_handlers.resolve_workspace_for_kernel(handler, "k1")
+
+        # Assert
+        offloaded = [func for func, _ in calls if func is _cell_handlers._resolve_workspace_id_from_cwd_sync]
+        assert offloaded, f"_resolve_workspace_id_from_cwd_sync が run_in_executor 経由で呼ばれていない: {calls}"
+        assert calls[0][1] == (f"{WORKSPACE_ROOT}/ws-a/sub",)
+        assert output_dir == tmp_path / "ws-a" / "output"
+        assert workspace_rel_path == "workspaces/sample/ws-a"
+
+
+class TestResolveWorkspaceForKernelErrorHandling:
+    """executor 越しの例外が既存の except Exception に届くことの検証（end-to-end 異常系）"""
+
+    @pytest.mark.asyncio
+    async def test_resolve_returns_none_tuple_for_cwd_outside_root(self):
+        """異常系: ワークスペース外の cwd では (None, None) を返す（例外を握りつぶさない）"""
+        handler = _make_handler(cwd=OUTSIDE_ROOT_CWD)
+
+        result = await _cell_handlers.resolve_workspace_for_kernel(handler, "k1")
+
+        assert result == (None, None)
+
+
+# async def 内でブロッキング I/O（Path.resolve）を行うプローブ。ruff の stdin に流す
+_RUFF_PROBE_SNIPPET = "from pathlib import Path\n\n\nasync def f(p: str) -> None:\n    Path(p).resolve()\n"
+
+
+class TestRuffAsyncGate:
+    """ruff ASYNC ゲート自体の回帰テスト（ソースツリーにプローブファイルを作らない）"""
+
+    def test_ruff_async_gate_detects_blocking_io(self):
+        """異常系: async 関数内のブロッキング I/O に対し ruff が exit 1 と ASYNC240 を返す"""
+        command = [
+            "uv",
+            "run",
+            "ruff",
+            "check",
+            "--stdin-filename",
+            "jupyter-server/extensions/custom_api/_probe.py",
+            "--output-format",
+            "concise",
+            "-",
+        ]
+        try:
+            result = subprocess.run(
+                command,
+                input=_RUFF_PROBE_SNIPPET,
+                capture_output=True,
+                text=True,
+                cwd=str(_repo_root),
+                check=False,
+            )
+        except FileNotFoundError:
+            pytest.skip("uv / ruff が未インストールのため skip")
+
+        # returncode が 0（違反なし）や 2 以上（ruff の実行エラー）の場合は skip せず fail させる
+        assert result.returncode == 1, (
+            f"ruff の returncode が 1 ではない: {result.returncode}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "ASYNC240" in result.stdout, f"ASYNC240 が報告されていない\nstdout:\n{result.stdout}"

--- a/jupyter-server/tests/test_workspace_sandbox.py
+++ b/jupyter-server/tests/test_workspace_sandbox.py
@@ -11,7 +11,9 @@ monkey patch が正しく設定されることを検証する。
 - 回帰テスト: ワークスペース外ファイルアクセス制限が引き続き動作する
 """
 
+import builtins
 import importlib.util
+import io
 import os
 import sys
 import tempfile
@@ -310,3 +312,57 @@ class TestFileRenameBlocked:
         os.replace(src, dst)
         assert os.path.exists(dst)
         assert not os.path.exists(src)
+
+
+class TestBuiltinsRestoredBetweenTests:
+    """conftest の restore_sandbox_patched_globals が builtins も巻き戻すことの検証
+
+    sandbox コードは `import builtins as _b` → `_b.open = _sandbox_open` で
+    プロセス全体の builtins.open を差し替える（workspace_sandbox.py:49,119）。
+    conftest の autouse フィクスチャがこれを復元しないと、以降の全テスト
+    （ファイルを跨ぐ）がパッチされた open を掴んだまま走る。
+
+    pytest はファイル内のテストを定義順に実行するため、
+    「1 つ目で exec → 2 つ目で復元済みを assert」という順序で汚染を検知する。
+    io.open は sandbox が触らない、パッチ前の組み込み open と同一のオブジェクト。
+    """
+
+    # 1 つ目のテストが作った他ワークスペースのファイル。3 つ目のテストが参照する
+    leaked_other_ws_file: str | None = None
+
+    def test_sandbox_patches_builtins_open(self, tmp_path):
+        """前提の確認: sandbox コードの exec は builtins.open を差し替える"""
+        ws_root = tmp_path / "workspaces"
+        ws_dir = ws_root / "ws-001"
+        other_ws = ws_root / "ws-002"
+        ws_dir.mkdir(parents=True)
+        other_ws.mkdir(parents=True)
+        other_file = other_ws / "secret.txt"
+        other_file.write_text("secret data")
+        # 後続テストが「漏れた制限」を検知できるよう、exec 前にパスを共有する
+        type(self).leaked_other_ws_file = str(other_file)
+
+        assert builtins.open is io.open, "テスト開始時点で builtins.open が汚染されている"
+
+        _exec_sandbox(str(ws_dir), "ws-001")
+
+        assert builtins.open is not io.open
+        assert builtins.open.__name__ == "_sandbox_open"
+
+    def test_builtins_open_restored_after_sandbox_test(self):
+        """前テストの sandbox パッチがテスト境界を越えて漏れていない"""
+        assert builtins.open is io.open, (
+            f"builtins.open が組み込みに復元されていない: {builtins.open!r}。"
+            "conftest の _SANDBOX_PATCHED_MODULES に builtins が含まれているか確認する"
+        )
+
+    def test_other_workspace_of_previous_test_readable(self):
+        """機能面の確認: 前テストの sandbox が課した制限が本テストに残っていない
+
+        復元されていなければ、漏れた _sandbox_open が前テストの
+        ワークスペースルート配下の他 WS パスを PermissionError で拒否する。
+        """
+        assert self.leaked_other_ws_file is not None, "先行テストが実行されていない"
+
+        with open(self.leaked_other_ws_file) as f:
+            assert f.read() == "secret data"

--- a/scripts/pyproject.toml
+++ b/scripts/pyproject.toml
@@ -9,7 +9,7 @@ target-version = "py311"
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "B", "SIM"]
+select = ["E", "F", "W", "I", "UP", "B", "SIM", "ASYNC"]
 ignore = ["E501"]
 
 [tool.ruff.format]


### PR DESCRIPTION
## Summary

タスク 11.2「ruff ASYNC ルールの有効化」。不変条件 I3（async コンテキストでブロッキング I/O をしない）を ruff の `ASYNC` ルールで機械検知できるようにする。

- **select 有効化**: jupyter-server / document-server / scripts の `pyproject.toml` の `select` に `"ASYNC"` を追加。CI 設定の変更は不要（既存の `python-lint-and-test` が `scripts/lint.sh` 経由で拾う）
- **ASYNC240 の 2 件を解消**: `cell_handlers.py` のカーネル cwd からのワークスペース解決を `_resolve_workspace_id_from_cwd_sync()` に切り出し、`run_in_executor` でオフロード。既存 8 箇所の `_*_sync` + executor イディオムに揃えた（9 個目）
- **ASYNC109 の 3 件は per-file-ignores で限定抑制**: `timeout` 引数は REST API が公開する契約であり、ロック取得後の deadline 計算・二段構えのタイムアウトのため呼び出し側の `asyncio.timeout` では代替できない。コンポーネント全体の `ignore` にはせず、`kernel_executor.py` / `sql_handlers.py` の 2 ファイルに限定（新規ファイルでは ASYNC109 が生きる）
- **テスト汚染の修正（計画外・単独実行で判明）**: sandbox コードが `builtins` / `os` / `subprocess` / `asyncio` / `Path` の属性をプロセス全体で書き換えたまま復元せず、テスト境界を越えて漏れていた。`conftest.py` に autouse フィクスチャを追加して巻き戻し、`test_workspace_sandbox.py` に復元の検証を追加
- **ドキュメント**: `.claude/rules/lint.md` に ASYNC240 の検知限界（`Path(root) / name` の join を挟むと型推論が切れる／`df.to_csv()` 等ライブラリ経由の I/O は原理的に未検知）と、ASYNC109 を per-file-ignores に限定する理由を追記
- **残債の起票**: ruff で検知できない `sql_handlers.py:697` の `df.to_csv()` オフロードを `docs/plan/01-jupyter.md` の Phase 26 として起票

**既知の限界**: 本ゲートは I3 の完全な保証ではなく部分的な網である。ゲートがグリーンでも async 関数内のブロッキング I/O は残りうる（詳細は `.claude/rules/lint.md`）。

## Test plan

- [x] 新規テスト `jupyter-server/tests/test_workspace_cwd_resolution.py` を**単独実行**で 6 件 pass（他ファイルのモック登録に依存していないことの確認）
  - 同期ヘルパーの正常系・異常系（ルート外 cwd で `ValueError`）・境界値（ルート自身で `None`）
  - `loop.run_in_executor` を spy し、実際にオフロード経由で呼ばれること（ヘルパー直接呼び出しの実装ミス検知）
  - end-to-end 異常系: executor 越しの `ValueError` が既存の `except Exception` に届き `(None, None)` が返る
  - ゲート自体の回帰: `async def` 内の `Path(p).resolve()` を ruff の stdin モードに流し exit 1 と `ASYNC240` を確認（ソースツリーにプローブファイルを作らない）
- [x] `scripts/test.sh --quiet jupyter-server` PASS
- [x] `scripts/test.sh --quiet document-server` PASS
- [x] `scripts/lint.sh` が `All checks passed.` を出力し exit 0
- [x] `uv run ruff check --statistics jupyter-server/extensions/` に `ASYNC240` 0 件
- [x] `uv run ruff check --select ASYNC109 jupyter-server/extensions/` が exit 0（per-file-ignores が効いている）
- [x] `uv run python scripts/check-docs-consistency.py` PASS
- 統合テストは対象外（`tests/integration/` に変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
